### PR TITLE
Rename app to Heartlytics across UI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Heart Disease Risk Prediction Web App
+# Heartlytics: Heart Disease Risk Prediction Web App
 
 A full-stack **Flask** application for predicting the risk of heart disease using a trained **Random Forest** model (scikit-learn).
 Users can enter patient data, upload CSV files for batch analysis, explore results in an interactive dashboard, and export rich PDF reports.
@@ -37,7 +37,7 @@ Users can enter patient data, upload CSV files for batch analysis, explore resul
 
 ## 📂 Project Structure
 ```text
-heart-app/
+Heartlytics/
 ├── app.py               # Application entry point
 ├── config.py            # Configuration classes
 ├── helpers.py           # Shared utility functions
@@ -83,8 +83,8 @@ heart-app/
 
 ### 1. Clone the repo
 ```bash
-git clone https://github.com/rasikasrimal/heart-disease-risk-app.git
-cd heart-disease-risk-app
+git clone https://github.com/rasikasrimal/Heartlytics.git
+cd Heartlytics
 ```
 
 ### 2. Create a virtual environment

--- a/app.py
+++ b/app.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-
 # ============================
-# Heart Disease Risk App + CSV Upload/EDA/Batch Predict
+# Heartlytics: Heart disease risk with CSV upload, EDA, batch prediction
 # ============================
 
 import os
@@ -1234,7 +1233,7 @@ def dashboard_pdf_generate():
         c.setFillColor(colors.HexColor("#dc2626"))
         c.drawString(cm, height - cm + 4, "\u2665")
         c.setFillColor(text_col)
-        c.drawString(cm + 14, height - cm, "Heart Disease Risk App")
+        c.drawString(cm + 14, height - cm, "Heartlytics")
         try:
             c.drawImage(
                 logo_path,

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}Heart Disease Risk{% endblock %}</title>
+    <title>{% block title %}Heartlytics{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -17,8 +17,8 @@
     <nav class="navbar navbar-expand-lg shadow-sm border-bottom sticky-top bg-body">
       <div class="container d-flex align-items-center">
         <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
-          <img src="{{ url_for('static', filename='logo.svg') }}" alt="logo" class="me-2" style="height:28px;width:28px;">
-          <strong>Heart App</strong>
+          <img src="{{ url_for('static', filename='logo.svg') }}" alt="Heartlytics logo" class="me-2" style="height:28px;width:28px;">
+          <strong>Heartlytics</strong>
         </a>
         <div class="collapse navbar-collapse" id="nav">
           <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
@@ -111,7 +111,7 @@
     </main>
 
     <footer class="py-4 text-center">
-      <small>&copy; {{ 2025 }} Heart App. For educational use only.</small>
+      <small>&copy; {{ 2025 }} Heartlytics. For educational use only.</small>
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Dashboard | Heart Disease Risk{% endblock %}
+{% block title %}Dashboard | Heartlytics{% endblock %}
 {% block head %}
   <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" defer></script>
 {% endblock %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ title or 'Error' }} | Heart Disease Risk{% endblock %}
+{% block title %}{{ title or 'Error' }} | Heartlytics{% endblock %}
 {% block content %}
 <div class="py-5 text-center">
   <i class="bi bi-exclamation-triangle-fill text-danger" style="font-size:4rem;"></i>

--- a/templates/predict/form.html
+++ b/templates/predict/form.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% block title %}Predict | Heart Disease Risk{% endblock %}
+{% block title %}Predict | Heartlytics{% endblock %}
 
 {% block content %}
 <div class="bg-dark text-light border rounded-4 p-5 text-center mb-4 shadow-sm">
-  <h1 class="display-6 fw-bold mb-2">Heart Disease Risk</h1>
+  <h1 class="display-6 fw-bold mb-2">Heartlytics</h1>
   <p class="helper-text mb-0">Single prediction & batch CSV analysis</p>
 </div>
 

--- a/templates/predict/result.html
+++ b/templates/predict/result.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Prediction | Heart Disease Risk{% endblock %}
+{% block title %}Prediction | Heartlytics{% endblock %}
 {% block head %}
   <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" defer></script>
 {% endblock %}

--- a/templates/research/index.html
+++ b/templates/research/index.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Research Paper | Heart Disease Risk{% endblock %}
+{% block title %}Research Paper | Heartlytics{% endblock %}
 {% block head %}
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" defer></script>
 {% endblock %}

--- a/templates/uploads/columns_map.html
+++ b/templates/uploads/columns_map.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Map Columns | Heart Disease Risk{% endblock %}
+{% block title %}Map Columns | Heartlytics{% endblock %}
 
 {% block content %}
 <div class="card shadow-sm">

--- a/templates/uploads/eda.html
+++ b/templates/uploads/eda.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}EDA & Cleaning | Heart Disease Risk{% endblock %}
+{% block title %}EDA & Cleaning | Heartlytics{% endblock %}
 {% block head %}
   <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" defer></script>
 {% endblock %}

--- a/templates/uploads/form.html
+++ b/templates/uploads/form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Upload CSV | Heart Disease Risk{% endblock %}
+{% block title %}Upload CSV | Heartlytics{% endblock %}
 {% block content %}
 <div class="row g-4">
   <div class="col-lg-5">

--- a/templates/uploads/preprocess.html
+++ b/templates/uploads/preprocess.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Preprocess | Heart Disease Risk{% endblock %}
+{% block title %}Preprocess | Heartlytics{% endblock %}
 {% block content %}
 <h1 class="h4 mb-3">Preview &amp; cleaning</h1>
 <div class="table-scroll mb-3">


### PR DESCRIPTION
## Summary
- rebrand application from "Heart App" to "Heartlytics" in templates, docs, and PDF reports
- update navbar, footer, titles, and headers to show Heartlytics
- refresh README with new project name

## Testing
- `pytest` *(fails: IntegrityError and status 400 in superadmin tests)*

------
https://chatgpt.com/codex/tasks/task_b_68ba8c88ad788327b7654f399dcf7411