### PR TITLE
Redirect doctors to dashboard after login

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -64,7 +64,7 @@ def login():
             if user.role == "Admin":
                 return redirect(url_for("superadmin.dashboard"))
             if user.role == "Doctor":
-                return redirect(url_for("doctor.dashboard"))
+                return redirect(url_for("dashboard"))
             return redirect(url_for("index"))
 
         data = session.get("login_attempts") or {"count": 0, "ts": datetime.utcnow().isoformat()}

--- a/tests/test_doctor_login_redirect.py
+++ b/tests/test_doctor_login_redirect.py
@@ -1,0 +1,23 @@
+"""Tests for doctor login redirection."""
+
+
+def test_doctor_redirect_to_dashboard(client):
+    from werkzeug.security import generate_password_hash
+    from app import db, User
+
+    # Ensure a doctor user exists
+    with client.application.app_context():
+        user = User.query.filter_by(username="redirectdoc").first()
+        if not user:
+            user = User(username="redirectdoc", email="rd@example.com", role="Doctor", status="approved")
+            db.session.add(user)
+        user.password_hash = generate_password_hash("redirectpass")
+        db.session.commit()
+
+    response = client.post(
+        "/auth/login",
+        data={"username": "redirectdoc", "password": "redirectpass"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/dashboard")


### PR DESCRIPTION
## Summary
- Redirect doctors to unified `/dashboard` after authentication
- Add test covering doctor login redirect

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68baa5d0086483279f549705bac8acc0