### PR TITLE
Add modular simulations framework with role-based access

### DIFF
--- a/app.py
+++ b/app.py
@@ -763,6 +763,7 @@ from superadmin import superadmin_bp
 from doctor import doctor_bp
 from user import user_bp
 from routes.settings import settings_bp
+from simulations import simulations_bp, register_simulations
 
 app.register_blueprint(predict_bp)
 app.register_blueprint(auth_bp)
@@ -770,6 +771,8 @@ app.register_blueprint(superadmin_bp)
 app.register_blueprint(doctor_bp)
 app.register_blueprint(user_bp)
 app.register_blueprint(settings_bp)
+register_simulations(app)
+app.register_blueprint(simulations_bp)
 
 
 @app.route("/admin/")

--- a/config.py
+++ b/config.py
@@ -25,6 +25,9 @@ class Config:
     )
     # Cache-busting version for logo; updated when SuperAdmin changes the logo
     LOGO_VERSION = os.environ.get("LOGO_VERSION", "1")
+    ENABLE_WHAT_IF = True
+    ENABLE_AGE_PROJECTION = True
+    ENABLE_LIFESTYLE_IMPACT = True
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/simulations/__init__.py
+++ b/simulations/__init__.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Blueprint registration for the simulations module."""
+
+from flask import Blueprint, render_template
+from flask_login import login_required
+
+from services.auth import role_required
+
+# Main blueprint exposing the /simulations namespace
+simulations_bp = Blueprint(
+    "simulations", __name__, url_prefix="/simulations", template_folder="templates"
+)
+
+@simulations_bp.route("/")
+@login_required
+@role_required(["Doctor", "SuperAdmin"])
+def dashboard():
+    """Render the simulations dashboard.
+
+    The page itself only bootstraps the front-end modules. Each simulation
+    feature lives in its own sub-blueprint so teams can develop them in
+    parallel without touching this file.
+    """
+
+    return render_template("dashboard.html")
+
+
+def register_simulations(app) -> None:
+    """Register simulation submodules based on feature flags."""
+
+    if app.config.get("ENABLE_WHAT_IF", True):
+        from .what_if import what_if_bp
+
+        simulations_bp.register_blueprint(what_if_bp)
+    if app.config.get("ENABLE_AGE_PROJECTION", True):
+        from .age_projection import age_projection_bp
+
+        simulations_bp.register_blueprint(age_projection_bp)
+    if app.config.get("ENABLE_LIFESTYLE_IMPACT", True):
+        from .lifestyle_impact import lifestyle_impact_bp
+
+        simulations_bp.register_blueprint(lifestyle_impact_bp)

--- a/simulations/age_projection/__init__.py
+++ b/simulations/age_projection/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+"""Age Projection simulation module."""
+
+from flask import Blueprint
+
+age_projection_bp = Blueprint("age_projection", __name__, url_prefix="/age-projection")
+
+from . import routes  # noqa: E402,F401

--- a/simulations/age_projection/routes.py
+++ b/simulations/age_projection/routes.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Routes for the age-based risk projection."""
+
+from flask import jsonify
+from flask_login import login_required
+
+from services.auth import role_required
+
+from . import age_projection_bp
+
+
+@age_projection_bp.get("/api")
+@login_required
+@role_required(["Doctor", "SuperAdmin"])
+def project() -> tuple:
+    """Return placeholder projection data.
+
+    The real implementation will calculate risk percentages across a range of
+    ages. This stub allows front-end development to proceed independently.
+    """
+
+    return jsonify({"ages": [], "risks": []}), 200

--- a/simulations/lifestyle_impact/__init__.py
+++ b/simulations/lifestyle_impact/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+"""Lifestyle Impact simulation module."""
+
+from flask import Blueprint
+
+lifestyle_impact_bp = Blueprint("lifestyle_impact", __name__, url_prefix="/lifestyle-impact")
+
+from . import routes  # noqa: E402,F401

--- a/simulations/lifestyle_impact/routes.py
+++ b/simulations/lifestyle_impact/routes.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Routes for lifestyle change simulations."""
+
+from flask import jsonify
+from flask_login import login_required
+
+from services.auth import role_required
+
+from . import lifestyle_impact_bp
+
+
+@lifestyle_impact_bp.get("/api")
+@login_required
+@role_required(["Doctor", "SuperAdmin"])
+def simulate() -> tuple:
+    """Return placeholder before/after comparison.
+
+    In future iterations this will recompute risk based on predefined lifestyle
+    modifications. The stub keeps the API stable for front-end work.
+    """
+
+    return jsonify({"before": 0, "after": 0}), 200

--- a/simulations/templates/dashboard.html
+++ b/simulations/templates/dashboard.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block title %}Simulations{% endblock %}
+
+{% block head %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Simulations</h1>
+<div id="what-if-section" class="mb-5">
+  <h2 class="h5">What-If Scenarios</h2>
+  <canvas id="whatIfChart"></canvas>
+</div>
+<div id="age-projection-section" class="mb-5">
+  <h2 class="h5">Future Risk Projection</h2>
+  <canvas id="ageProjectionChart"></canvas>
+</div>
+<div id="lifestyle-impact-section" class="mb-5">
+  <h2 class="h5">Lifestyle Impact Simulator</h2>
+  <canvas id="lifestyleImpactChart"></canvas>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='simulations/main.js') }}"></script>
+{% endblock %}

--- a/simulations/what_if/__init__.py
+++ b/simulations/what_if/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+"""What-If simulation module."""
+
+from flask import Blueprint
+
+what_if_bp = Blueprint("what_if", __name__, url_prefix="/what-if")
+
+from . import routes  # noqa: E402,F401

--- a/simulations/what_if/routes.py
+++ b/simulations/what_if/routes.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Routes for the What-If simulation."""
+
+from flask import jsonify
+from flask_login import login_required
+
+from services.auth import role_required
+
+from . import what_if_bp
+
+
+@what_if_bp.get("/api")
+@login_required
+@role_required(["Doctor", "SuperAdmin"])
+def simulate() -> tuple:
+    """Return placeholder risk data for a single-variable tweak.
+
+    The actual implementation will compute a new risk percentage based on the
+    provided variable adjustments. Returning an empty structure keeps the
+    endpoint stable during parallel development.
+    """
+
+    return jsonify({"points": []}), 200

--- a/static/simulations/main.js
+++ b/static/simulations/main.js
@@ -1,0 +1,34 @@
+async function fetchAndPlot(url, canvasId) {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(res.statusText);
+    const data = await res.json();
+    const ctx = document.getElementById(canvasId);
+    if (!ctx) return;
+    let labels = [];
+    let values = [];
+    if (data.points) {
+      labels = data.points.map(p => p.label);
+      values = data.points.map(p => p.value);
+    } else if (data.ages && data.risks) {
+      labels = data.ages;
+      values = data.risks;
+    } else if (data.before !== undefined && data.after !== undefined) {
+      labels = ['Before', 'After'];
+      values = [data.before, data.after];
+    }
+    new Chart(ctx, {
+      type: 'line',
+      data: {labels: labels, datasets: [{label: 'Risk %', data: values}]},
+      options: {responsive: true}
+    });
+  } catch (err) {
+    console.error('Simulation module failed:', url, err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchAndPlot('/simulations/what-if/api', 'whatIfChart');
+  fetchAndPlot('/simulations/age-projection/api', 'ageProjectionChart');
+  fetchAndPlot('/simulations/lifestyle-impact/api', 'lifestyleImpactChart');
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,6 +44,13 @@
                 <i class="bi bi-journal-text me-1"></i>Research
               </a>
             </li>
+              {% if current_user.role in ['Doctor','SuperAdmin'] %}
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center {% if request.endpoint.startswith('simulations.') %}active{% endif %}" href="{{ url_for('simulations.dashboard') }}">
+                  <i class="bi bi-graph-up me-1"></i>Simulations
+                </a>
+              </li>
+              {% endif %}
             {% if current_user.role == 'Admin' %}
             <li class="nav-item">
               <a class="nav-link d-flex align-items-center {% if request.endpoint.startswith('superadmin.') %}active{% endif %}" href="{{ sa_url('superadmin.dashboard') }}">


### PR DESCRIPTION
## Summary
- Add simulations blueprint and register modular sub-blueprints for what-if, age projection, and lifestyle impact simulators
- Gate simulations page to Doctor and SuperAdmin roles and add feature flags for toggling modules
- Introduce frontend assets and navigation link for simulations with resilient Chart.js rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68baa52476dc8327b0e50bd1f6fff21e