### PR TITLE
Refine risk simulation chart

### DIFF
--- a/simulations/templates/simulations/index.html
+++ b/simulations/templates/simulations/index.html
@@ -125,56 +125,20 @@
 {% endif %}
 {% if results.exercise_angina %}
 <div class="mb-5">
-  <h2>Exercise Angina Impact</h2>
+  <h2>Heart disease risk change with {{ results.exercise_angina.label }}</h2>
   <div id="exercise-angina-chart" style="height:350px;"></div>
-</div>
-{% endif %}
-{% if results.what_if %}
-<div class="mb-5">
-  <h2>What-If: {{ results.what_if.variable }}</h2>
-  <div id="what-if-chart" style="height:350px;"></div>
-</div>
-{% endif %}
-{% if results.age_projection %}
-<div class="mb-5">
-  <h2>Age Projection</h2>
-  <div id="age-projection" style="height:350px;"></div>
 </div>
 {% endif %}
 {% endblock %}
 {% block scripts %}
   {{ super() }}
-  {% if results.what_if %}
-  <script>
-  document.addEventListener('DOMContentLoaded', function() {
-    var seg = {{ results.what_if.segments|tojson }};
-    var traces = [];
-    if(seg.low.length){ traces.push({x:seg.low.map(r=>r.value), y:seg.low.map(r=>r.risk_pct), mode:'lines', line:{color:'green'}}); }
-    if(seg.mid.length){ traces.push({x:seg.mid.map(r=>r.value), y:seg.mid.map(r=>r.risk_pct), mode:'lines', line:{color:'yellow'}}); }
-    if(seg.high.length){ traces.push({x:seg.high.map(r=>r.value), y:seg.high.map(r=>r.risk_pct), mode:'lines', line:{color:'red'}}); }
-    Plotly.newPlot('what-if-chart', traces, {xaxis:{title:'{{ results.what_if.variable }}'}, yaxis:{title:'Risk (%)', rangemode:'tozero'}, margin:{t:30}});
-  });
-  </script>
-  {% endif %}
   {% if results.exercise_angina %}
   <script>
   document.addEventListener('DOMContentLoaded', function() {
     var res = {{ results.exercise_angina|tojson }};
     var no = {x: res.no.map(r=>r.value), y: res.no.map(r=>r.risk_pct), mode:'lines', name:'No Angina', line:{color:'green'}};
     var yes = {x: res.yes.map(r=>r.value), y: res.yes.map(r=>r.risk_pct), mode:'lines', name:'Yes Angina', line:{color:'red'}};
-    Plotly.newPlot('exercise-angina-chart', [no, yes], {xaxis:{title: res.label}, yaxis:{title:'Risk (%)', rangemode:'tozero'}, margin:{t:30}});
-  });
-  </script>
-  {% endif %}
-  {% if results.age_projection %}
-  <script>
-  document.addEventListener('DOMContentLoaded', function() {
-    var seg = {{ results.age_projection|tojson }};
-    var traces = [];
-    if(seg.low.length){ traces.push({x:seg.low.map(r=>r.age), y:seg.low.map(r=>r.risk_pct), mode:'lines', line:{color:'green'}}); }
-    if(seg.mid.length){ traces.push({x:seg.mid.map(r=>r.age), y:seg.mid.map(r=>r.risk_pct), mode:'lines', line:{color:'yellow'}}); }
-    if(seg.high.length){ traces.push({x:seg.high.map(r=>r.age), y:seg.high.map(r=>r.risk_pct), mode:'lines', line:{color:'red'}}); }
-    Plotly.newPlot('age-projection', traces, {xaxis:{title:'Age'}, yaxis:{title:'Risk (%)', rangemode:'tozero'}, margin:{t:30}});
+    Plotly.newPlot('exercise-angina-chart', [no, yes], {xaxis:{title: res.label, range:[res.vmin, res.vmax]}, yaxis:{title:'Risk (%)', range:[0,100]}, margin:{t:30}});
   });
   </script>
   {% endif %}

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -4,3 +4,6 @@ def test_simulations_page(auth_client):
     resp = auth_client.get("/simulations/?variable=age")
     assert resp.status_code == 200
     assert b'exercise-angina-chart' in resp.data
+    assert b'Heart disease risk change with Age' in resp.data
+    assert b'What-If' not in resp.data
+    assert b'Age Projection' not in resp.data


### PR DESCRIPTION
## Summary
- simplify simulations dashboard to a single "Heart disease risk change" chart
- allow selecting variable for angina comparison and fix axis ranges
- remove unused What-If and age projection charts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bad9a333748327ac7a4a40b2548947