### PR TITLE
Add exercise angina risk simulation

### DIFF
--- a/simulations/routes.py
+++ b/simulations/routes.py
@@ -14,87 +14,135 @@ from . import simulations_bp
 from .angina_curve import simulate_angina_sensitivity
 
 
-@simulations_bp.route("/")
+@simulations_bp.route("/", methods=["GET", "POST"])
 @login_required
 @role_required(["Doctor", "SuperAdmin"])
 def index():
     """Render simulations page with enabled modules."""
     model = current_app.model
 
-    # Collect full patient data (defaults provided)
-    baseline = {
-        "age": int(request.args.get("age", 50)),
-        "sex": int(request.args.get("sex", 1)),
-        "chest_pain_type": request.args.get("chest_pain_type", "non-anginal"),
-        "resting_blood_pressure": float(request.args.get("resting_blood_pressure", 120)),
-        "cholesterol": float(request.args.get("cholesterol", 200)),
-        "fasting_blood_sugar": float(request.args.get("fasting_blood_sugar", 100)),
-        "Restecg": request.args.get("Restecg", "normal"),
-        "max_heart_rate_achieved": float(request.args.get("max_heart_rate_achieved", 150)),
-        "exercise_induced_angina": int(request.args.get("exercise_induced_angina", 0)),
-        "st_depression": float(request.args.get("st_depression", 1.0)),
-        "st_slope_type": request.args.get("st_slope_type", "flat"),
-        "num_major_vessels": int(request.args.get("num_major_vessels", 0)),
-        "thalassemia_type": request.args.get("thalassemia_type", "normal"),
+    defaults = {
+        "age": 50,
+        "sex": 1,
+        "chest_pain_type": "non-anginal",
+        "resting_blood_pressure": 120.0,
+        "cholesterol": 200.0,
+        "fasting_blood_sugar": 100.0,
+        "Restecg": "normal",
+        "max_heart_rate_achieved": 150.0,
+        "exercise_induced_angina": 0,
+        "st_depression": 1.0,
+        "st_slope_type": "flat",
+        "num_major_vessels": 0,
+        "thalassemia_type": "normal",
     }
 
     results: dict = {}
     errors: dict = {}
     prediction = None
+    variable = "age"
 
-    # Baseline prediction with confidence
-    try:
-        X = pd.DataFrame([baseline], columns=INPUT_COLUMNS)
-        yhat = int(model.predict(X)[0])
-        pos_prob = (
-            float(model.predict_proba(X)[0][1])
-            if hasattr(model, "predict_proba")
-            else None
-        )
-        confidence = pos_prob if yhat == 1 else (1.0 - pos_prob) if pos_prob is not None else None
-        prediction = {
-            "label": "Heart Disease" if yhat == 1 else "No Heart Disease",
-            "risk_pct": round(pos_prob * 100.0, 1) if pos_prob is not None else None,
-            "confidence_pct": round(confidence * 100.0, 1) if confidence is not None else None,
+    if request.method == "POST":
+        form = request.form
+        baseline = {
+            "age": int(form.get("age", defaults["age"])),
+            "sex": int(form.get("sex", defaults["sex"])),
+            "chest_pain_type": form.get("chest_pain_type", defaults["chest_pain_type"]),
+            "resting_blood_pressure": float(
+                form.get("resting_blood_pressure", defaults["resting_blood_pressure"])
+            ),
+            "cholesterol": float(form.get("cholesterol", defaults["cholesterol"])),
+            "fasting_blood_sugar": float(
+                form.get("fasting_blood_sugar", defaults["fasting_blood_sugar"])
+            ),
+            "Restecg": form.get("Restecg", defaults["Restecg"]),
+            "max_heart_rate_achieved": float(
+                form.get("max_heart_rate_achieved", defaults["max_heart_rate_achieved"])
+            ),
+            "exercise_induced_angina": int(
+                form.get("exercise_induced_angina", defaults["exercise_induced_angina"])
+            ),
+            "st_depression": float(form.get("st_depression", defaults["st_depression"])),
+            "st_slope_type": form.get("st_slope_type", defaults["st_slope_type"]),
+            "num_major_vessels": int(
+                form.get("num_major_vessels", defaults["num_major_vessels"])
+            ),
+            "thalassemia_type": form.get("thalassemia_type", defaults["thalassemia_type"]),
         }
-    except Exception as e:  # pragma: no cover - defensive
-        errors["prediction"] = str(e)
 
-    variable = request.args.get("variable", "age")
-    ranges = {
-        "age": (0, 120),
-        "resting_blood_pressure": (80, 250),
-        "cholesterol": (100, 600),
-        "fasting_blood_sugar": (60, 200),
-        "max_heart_rate_achieved": (60, 220),
-        "st_depression": (0, 10),
-    }
+        variable = form.get("variable", "age")
 
-    try:
-        vmin, vmax = ranges.get(
-            variable, (baseline.get(variable, 0) - 50, baseline.get(variable, 0) + 50)
-        )
-        steps = 50
-        step = (vmax - vmin) / steps
-        values = [vmin + i * step for i in range(steps + 1)]
-        curves = simulate_angina_sensitivity(model, baseline, variable, values)
-        labels = {
-            "age": "Age",
-            "cholesterol": "Cholesterol (mg/dL)",
-            "resting_blood_pressure": "Resting Blood Pressure (systolic mmHg)",
-            "fasting_blood_sugar": "Fasting Blood Sugar / Glucose (mg/dL)",
-            "max_heart_rate_achieved": "Max Heart Rate Achieved (bpm)",
+        # Baseline prediction with confidence
+        try:
+            X = pd.DataFrame([baseline], columns=INPUT_COLUMNS)
+            yhat = int(model.predict(X)[0])
+            pos_prob = (
+                float(model.predict_proba(X)[0][1])
+                if hasattr(model, "predict_proba")
+                else None
+            )
+            confidence = (
+                pos_prob
+                if yhat == 1
+                else (1.0 - pos_prob)
+                if pos_prob is not None
+                else None
+            )
+            prediction = {
+                "label": "Heart Disease" if yhat == 1 else "No Heart Disease",
+                "risk_pct": round(pos_prob * 100.0, 1) if pos_prob is not None else None,
+                "confidence_pct": round(confidence * 100.0, 1)
+                if confidence is not None
+                else None,
+            }
+        except Exception as e:  # pragma: no cover - defensive
+            errors["prediction"] = str(e)
+
+        ranges = {
+            "age": (0, 120),
+            "resting_blood_pressure": (80, 250),
+            "cholesterol": (100, 600),
+            "fasting_blood_sugar": (60, 200),
+            "max_heart_rate_achieved": (60, 220),
+            "st_depression": (0, 10),
         }
-        results["exercise_angina"] = {
-            "variable": variable,
-            "label": labels.get(variable, variable),
-            "vmin": vmin,
-            "vmax": vmax,
-            "no": curves["no"],
-            "yes": curves["yes"],
-        }
-    except Exception as e:  # pragma: no cover - defensive
-        errors["exercise_angina"] = str(e)
+
+        try:
+            vmin, vmax = ranges.get(
+                variable, (baseline.get(variable, 0) - 50, baseline.get(variable, 0) + 50)
+            )
+            steps = 50
+            step = (vmax - vmin) / steps
+            values = [vmin + i * step for i in range(steps + 1)]
+            curves = simulate_angina_sensitivity(model, baseline, variable, values)
+            labels = {
+                "age": "Age",
+                "cholesterol": "Cholesterol (mg/dL)",
+                "resting_blood_pressure": "Resting Blood Pressure (systolic mmHg)",
+                "fasting_blood_sugar": "Fasting Blood Sugar / Glucose (mg/dL)",
+                "max_heart_rate_achieved": "Max Heart Rate Achieved (bpm)",
+            }
+            current = simulate_angina_sensitivity(
+                model, baseline, variable, [baseline[variable]]
+            )
+            current_key = "yes" if baseline["exercise_induced_angina"] else "no"
+            results["exercise_angina"] = {
+                "variable": variable,
+                "label": labels.get(variable, variable),
+                "vmin": vmin,
+                "vmax": vmax,
+                "no": curves["no"],
+                "yes": curves["yes"],
+                "current": {
+                    "value": baseline[variable],
+                    "risk_pct": current[current_key][0]["risk_pct"],
+                    "angina": baseline["exercise_induced_angina"],
+                },
+            }
+        except Exception as e:  # pragma: no cover - defensive
+            errors["exercise_angina"] = str(e)
+    else:
+        baseline = defaults.copy()
 
     return render_template(
         "simulations/index.html",
@@ -102,4 +150,5 @@ def index():
         prediction=prediction,
         results=results,
         errors=errors,
+        variable=variable,
     )

--- a/simulations/templates/simulations/index.html
+++ b/simulations/templates/simulations/index.html
@@ -5,22 +5,22 @@
 {% endblock %}
 {% block content %}
 <h1 class="mb-4">Simulations</h1>
-<form method="get" class="row g-3 mb-4">
+<form method="post" class="row g-3 mb-4">
   <div class="col-md-3">
     <label class="form-label">Age</label>
-    <input type="number" class="form-control" name="age" value="{{ request.args.get('age', 50) }}">
+    <input type="number" class="form-control" name="age" value="{{ baseline.age }}">
   </div>
   <div class="col-md-3">
     <label class="form-label">Sex</label>
     <select class="form-select" name="sex">
-      <option value="1" {% if request.args.get('sex','1')=='1' %}selected{% endif %}>1</option>
-      <option value="0" {% if request.args.get('sex')=='0' %}selected{% endif %}>0</option>
+      <option value="1" {% if baseline.sex==1 %}selected{% endif %}>1</option>
+      <option value="0" {% if baseline.sex==0 %}selected{% endif %}>0</option>
     </select>
   </div>
   <div class="col-md-3">
     <label class="form-label">Chest Pain Type</label>
     <select class="form-select" name="chest_pain_type">
-      {% set cpt = request.args.get('chest_pain_type','non-anginal') %}
+      {% set cpt = baseline.chest_pain_type %}
       {% for v in ['typical_angina','atypical_angina','non-anginal','asymptomatic'] %}
       <option value="{{ v }}" {% if cpt==v %}selected{% endif %}>{{ v }}</option>
       {% endfor %}
@@ -29,7 +29,7 @@
   <div class="col-md-3">
     <label class="form-label">Country</label>
     <select class="form-select" name="country">
-      {% set country = request.args.get('country','Cleveland') %}
+      {% set country = request.form.get('country','Cleveland') %}
       {% for v in ['Cleveland','Hungary','Switzerland','Long_Beach'] %}
       <option value="{{ v }}" {% if country==v %}selected{% endif %}>{{ v }}</option>
       {% endfor %}
@@ -37,20 +37,20 @@
   </div>
   <div class="col-md-3">
     <label class="form-label">Resting BP</label>
-    <input type="number" class="form-control" name="resting_blood_pressure" value="{{ request.args.get('resting_blood_pressure',120) }}">
+    <input type="number" class="form-control" name="resting_blood_pressure" value="{{ baseline.resting_blood_pressure }}">
   </div>
   <div class="col-md-3">
     <label class="form-label">Cholesterol</label>
-    <input type="number" class="form-control" name="cholesterol" value="{{ request.args.get('cholesterol',200) }}">
+    <input type="number" class="form-control" name="cholesterol" value="{{ baseline.cholesterol }}">
   </div>
   <div class="col-md-3">
     <label class="form-label">Fasting Blood Sugar / Glucose (mg/dL)</label>
-    <input type="number" class="form-control" name="fasting_blood_sugar" value="{{ request.args.get('fasting_blood_sugar',100) }}">
+    <input type="number" class="form-control" name="fasting_blood_sugar" value="{{ baseline.fasting_blood_sugar }}">
   </div>
   <div class="col-md-3">
     <label class="form-label">Resting ECG</label>
     <select class="form-select" name="Restecg">
-      {% set recg = request.args.get('Restecg','normal') %}
+      {% set recg = baseline.Restecg %}
       {% for v in ['normal','left_ventricular_hypertrophy','st_t_wave_abnormality'] %}
       <option value="{{ v }}" {% if recg==v %}selected{% endif %}>{{ v }}</option>
       {% endfor %}
@@ -58,24 +58,23 @@
   </div>
   <div class="col-md-3">
     <label class="form-label">Max Heart Rate</label>
-    <input type="number" class="form-control" name="max_heart_rate_achieved" value="{{ request.args.get('max_heart_rate_achieved',150) }}">
+    <input type="number" class="form-control" name="max_heart_rate_achieved" value="{{ baseline.max_heart_rate_achieved }}">
   </div>
   <div class="col-md-3">
     <label class="form-label">Exercise Angina</label>
     <select class="form-select" name="exercise_induced_angina">
-      {% set exa = request.args.get('exercise_induced_angina','0') %}
-      <option value="0" {% if exa=='0' %}selected{% endif %}>0</option>
-      <option value="1" {% if exa=='1' %}selected{% endif %}>1</option>
+      <option value="0" {% if baseline.exercise_induced_angina==0 %}selected{% endif %}>0</option>
+      <option value="1" {% if baseline.exercise_induced_angina==1 %}selected{% endif %}>1</option>
     </select>
   </div>
   <div class="col-md-3">
     <label class="form-label">ST Depression</label>
-    <input type="number" step="0.1" class="form-control" name="st_depression" value="{{ request.args.get('st_depression',1.0) }}">
+    <input type="number" step="0.1" class="form-control" name="st_depression" value="{{ baseline.st_depression }}">
   </div>
   <div class="col-md-3">
     <label class="form-label">ST Slope Type</label>
     <select class="form-select" name="st_slope_type">
-      {% set slope = request.args.get('st_slope_type','flat') %}
+      {% set slope = baseline.st_slope_type %}
       {% for v in ['upsloping','flat','downsloping'] %}
       <option value="{{ v }}" {% if slope==v %}selected{% endif %}>{{ v }}</option>
       {% endfor %}
@@ -83,12 +82,12 @@
   </div>
   <div class="col-md-3">
     <label class="form-label">Num Major Vessels</label>
-    <input type="number" class="form-control" name="num_major_vessels" value="{{ request.args.get('num_major_vessels',0) }}">
+    <input type="number" class="form-control" name="num_major_vessels" value="{{ baseline.num_major_vessels }}">
   </div>
   <div class="col-md-3">
     <label class="form-label">Thalassemia Type</label>
     <select class="form-select" name="thalassemia_type">
-      {% set thal = request.args.get('thalassemia_type','normal') %}
+      {% set thal = baseline.thalassemia_type %}
       {% for v in ['normal','fixed_defect','reversible_defect'] %}
       <option value="{{ v }}" {% if thal==v %}selected{% endif %}>{{ v }}</option>
       {% endfor %}
@@ -97,7 +96,6 @@
   <div class="col-md-3">
     <label class="form-label">Variable</label>
     <select class="form-select" name="variable">
-      {% set variable = request.args.get('variable','age') %}
       <option value="age" {% if variable=='age' %}selected{% endif %}>Age</option>
       <option value="cholesterol" {% if variable=='cholesterol' %}selected{% endif %}>Cholesterol (mg/dL)</option>
       <option value="resting_blood_pressure" {% if variable=='resting_blood_pressure' %}selected{% endif %}>Resting Blood Pressure (systolic mmHg)</option>
@@ -138,7 +136,8 @@
     var res = {{ results.exercise_angina|tojson }};
     var no = {x: res.no.map(r=>r.value), y: res.no.map(r=>r.risk_pct), mode:'lines', name:'No Angina', line:{color:'green'}};
     var yes = {x: res.yes.map(r=>r.value), y: res.yes.map(r=>r.risk_pct), mode:'lines', name:'Yes Angina', line:{color:'red'}};
-    Plotly.newPlot('exercise-angina-chart', [no, yes], {xaxis:{title: res.label, range:[res.vmin, res.vmax]}, yaxis:{title:'Risk (%)', range:[0,100]}, margin:{t:30}});
+    var cur = {x:[res.current.value], y:[res.current.risk_pct], mode:'markers+text', text:['You\'re here'], textposition:'top center', marker:{color:res.current.angina ? 'red':'green', size:8}, showlegend:false};
+    Plotly.newPlot('exercise-angina-chart', [no, yes, cur], {xaxis:{title: res.label, range:[res.vmin, res.vmax]}, yaxis:{title:'Risk (%)', range:[0,100]}, margin:{t:30}});
   });
   </script>
   {% endif %}

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,9 +1,14 @@
 """Tests for simulations page."""
 
 def test_simulations_page(auth_client):
-    resp = auth_client.get("/simulations/?variable=age")
+    resp = auth_client.get("/simulations/")
     assert resp.status_code == 200
-    assert b'exercise-angina-chart' in resp.data
-    assert b'Heart disease risk change with Age' in resp.data
-    assert b'What-If' not in resp.data
-    assert b'Age Projection' not in resp.data
+    assert b"exercise-angina-chart" not in resp.data
+
+    resp = auth_client.post("/simulations/", data={"variable": "age"})
+    assert resp.status_code == 200
+    assert b"exercise-angina-chart" in resp.data
+    assert b"Heart disease risk change with Age" in resp.data
+    assert b"You\\'re here" in resp.data
+    assert b"What-If" not in resp.data
+    assert b"Age Projection" not in resp.data


### PR DESCRIPTION
## Summary
- avoid running simulation on initial load to keep `/simulations/` URL clean
- mark the user's current value on the heart disease risk change chart
- adjust simulation tests for the deferred run and new marker

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68badc6c5ec483278cb24e878baf7651