### PR TITLE
Redirect doctors to dashboard after login

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -64,7 +64,7 @@ def login():
             if user.role == "Admin":
                 return redirect(url_for("superadmin.dashboard"))
             if user.role == "Doctor":
-                return redirect(url_for("doctor.dashboard"))
+                return redirect(url_for("dashboard"))
             return redirect(url_for("index"))
 
         data = session.get("login_attempts") or {"count": 0, "ts": datetime.utcnow().isoformat()}


### PR DESCRIPTION
## Summary
- Route doctors to `/dashboard` by default after successful login

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bae4367a708327ba741f3c6917b0b0