### PR TITLE
docs: revise readme and add test case coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ Users can enter patient data, upload CSV files for batch analysis, explore resul
   - Exports all visuals and records to a styled PDF with table of contents and responsive column widths
 - 📑 **Patient PDF Reports**: Generate downloadable patient-level summaries with all inputs, prediction, probability, risk band, and confidence.
 - 📚 **Research Paper Viewer**: Renders a bundled LaTeX manuscript with MathJax, tables, figures, and reference links.
+- 👥 **Role-Based Access Control**: Users, Doctors, Admins, and SuperAdmins with dedicated dashboards, account approval workflow, and audit logs.
+- 🩺 **Doctor Portal**: Doctors can review their own patient predictions and histories.
+- ⚙️ **Profile Settings**: Update username, email, nickname, avatar, and password while viewing recent activity logs.
+- 🧪 **Simulations**: What-if analysis and risk projections for variables such as age or exercise-induced angina.
+- 🕵️ **Outlier Detection**: Batch EDA includes IQR, Isolation Forest, Z-Score, LOF, and DBSCAN methods to highlight anomalous records.
 
 - 🎨 **Modern UI**: Responsive Bootstrap 5 theme with custom colors, icons, and charts.
 - 🔒 **Safe by design**:
   - CSRF tokens for forms and API
   - Security headers (no-sniff, frame denial, no referrer, no FLoC)
+  - Login rate limiting and session timeouts
   - 🗄 **Persistence**: SQLite database via SQLAlchemy, storing predictions with metadata.
 
 ---
@@ -42,17 +48,21 @@ heart-app/
 ├── config.py            # Configuration classes
 ├── helpers.py           # Shared utility functions
 ├── outlier_detection.py # Outlier detection helpers
-├── admin/               # Admin blueprint
 ├── auth/                # Authentication blueprint and forms
+├── doctor/              # Doctor dashboard
 ├── routes/              # Core Flask blueprints
 │   ├── __init__.py
-│   └── predict.py
+│   ├── predict.py
+│   └── settings.py
 ├── services/            # Business logic and ML helpers
 │   ├── auth.py
 │   ├── data.py
 │   ├── pdf.py
 │   ├── security.py
 │   └── simulation.py
+├── simulations/         # What-if risk modules
+├── superadmin/          # Superadmin dashboard and management
+├── user/                # Basic user dashboard
 ├── templates/           # Jinja2 templates
 │   ├── base.html
 │   ├── error.html
@@ -65,7 +75,6 @@ heart-app/
 │   └── sample.csv
 ├── ml/                  # Trained model artifacts
 │   └── model.pkl
-├── superadmin/          # Superadmin blueprint
 ├── tests/               # Pytest suites
 │   ├── test_predict.py
 │   └── ...
@@ -76,6 +85,11 @@ heart-app/
 ## 🗺️ Blueprints
 
 - `predict` – renders the prediction form and returns the model's risk assessment.
+- `settings` – profile management and activity logs.
+- `simulations` – interactive what‑if analysis tools.
+- `doctor` – dashboard for doctors to view their patients.
+- `user` – simple dashboard for regular users.
+- `superadmin` – user management, approvals, and audit logs.
 
 ---
 

--- a/TEST_CASES.md
+++ b/TEST_CASES.md
@@ -1,0 +1,90 @@
+# Test Cases
+
+## Authentication & Roles
+- **Login succeeds**
+  1. Navigate to `/auth/login`.
+  2. Enter valid credentials and submit.
+  - Expected: user is redirected to their dashboard.
+- **Login rate limit**
+  1. Attempt to log in with invalid credentials five times.
+  - Expected: further attempts show "Too many login attempts".
+- **Signup requires approval for Doctors/Admins**
+  1. Submit the signup form selecting the Doctor role.
+  - Expected: account status is `pending` and cannot log in until approved.
+- **Role restriction**
+  1. Log in as a regular user.
+  2. Navigate to `/superadmin`.
+  - Expected: `403 Forbidden`.
+
+## Prediction
+- **Single prediction**
+  1. Open the home page and submit the prediction form with valid data.
+  - Expected: prediction label, probability, risk band, and confidence are displayed.
+- **Validation errors**
+  1. Submit the prediction form with invalid values (e.g., text in numeric field).
+  - Expected: form redisplays with error messages.
+- **Patient PDF report**
+  1. After a prediction, click the PDF download link.
+  - Expected: PDF containing patient details and model outputs is downloaded.
+
+## Batch Upload & EDA
+- **CSV upload**
+  1. Navigate to the upload page and drop a CSV file.
+  2. Map columns and start the batch process.
+  - Expected: cleaned data preview and progress feedback.
+- **Outlier detection**
+  1. Run EDA after upload.
+  - Expected: tables highlighting IQR, Isolation Forest, Z‑Score, LOF, and DBSCAN outliers.
+- **Dashboard export**
+  1. From the dashboard, export the PDF report.
+  - Expected: PDF with KPIs, charts, and table of contents.
+
+## Doctor Dashboard
+- **Doctor sees own patients**
+  1. Log in as a doctor who has submitted predictions.
+  - Expected: dashboard lists only patients entered by that doctor.
+
+## SuperAdmin Management
+- **Approve user**
+  1. Log in as SuperAdmin and open the dashboard.
+  2. Approve a pending user.
+  - Expected: user status changes to `approved`.
+- **Change role or status**
+  1. From the dashboard, update a user's role or suspend them.
+  - Expected: change is persisted and recorded in audit logs.
+- **Reset password**
+  1. Trigger a password reset for a user.
+  - Expected: temporary password is displayed.
+- **View audit log**
+  1. Open `/superadmin/audit`.
+  - Expected: paginated list of administrative actions.
+
+## User Settings
+- **Update profile and avatar**
+  1. Navigate to `/settings` and change profile fields and upload an avatar.
+  - Expected: new information and image are saved.
+- **Change password**
+  1. Provide current and new passwords on the settings page.
+  - Expected: password updated confirmation.
+- **Activity log**
+  1. Visit `/settings`.
+  - Expected: recent actions appear in the activity table.
+
+## Simulations
+- **Exercise‑induced angina sensitivity**
+  1. Open `/simulations` and run the simulation for different variables.
+  - Expected: curves display risk changes and highlight the current baseline.
+
+## Research Paper Viewer
+- **Paper renders**
+  1. Navigate to `/research` (or corresponding route).
+  - Expected: LaTeX manuscript rendered with sections, figures, and references.
+
+## Security
+- **CSRF protection**
+  1. Submit a POST request without the CSRF token.
+  - Expected: request is rejected.
+- **Session timeout**
+  1. Log in and remain idle beyond the configured timeout.
+  - Expected: user is logged out on next request.
+


### PR DESCRIPTION
## Summary
- document role-based access, simulations, and outlier detection features
- describe doctor, user, and superadmin blueprints in project structure
- add comprehensive manual test cases for old and new features

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bae5f311f8832782cf7b4488db188a