### PR TITLE
Refactor simulations UI for dynamic two-column layout: reposition variable controls

### DIFF
--- a/simulations/routes.py
+++ b/simulations/routes.py
@@ -80,7 +80,8 @@ def _run_simulation(form: dict, defaults: dict):
         "cholesterol": (100, 600),
         "fasting_blood_sugar": (60, 200),
         "max_heart_rate_achieved": (60, 220),
-        "st_depression": (0, 10),
+        "st_depression": (0, 6.2),
+        "num_major_vessels": (0, 3),
     }
 
     try:
@@ -97,6 +98,8 @@ def _run_simulation(form: dict, defaults: dict):
             "resting_blood_pressure": "Resting Blood Pressure (systolic mmHg)",
             "fasting_blood_sugar": "Fasting Blood Sugar / Glucose (mg/dL)",
             "max_heart_rate_achieved": "Max Heart Rate Achieved (bpm)",
+            "st_depression": "ST Depression",
+            "num_major_vessels": "Num Major Vessels",
         }
         current = simulate_angina_sensitivity(
             model, baseline, variable, [baseline[variable]]

--- a/simulations/templates/simulations/index.html
+++ b/simulations/templates/simulations/index.html
@@ -77,7 +77,7 @@
           </div>
           <div class="mb-3">
             <label class="form-label">ST Depression</label>
-            <input type="range" step="0.1" class="form-range" name="st_depression" id="st_dep" min="0" max="10" value="{{ baseline.st_depression }}">
+            <input type="range" step="0.1" class="form-range" name="st_depression" id="st_dep" min="0" max="6.2" value="{{ baseline.st_depression }}">
             <div class="form-text"><span id="st_dep-value">{{ baseline.st_depression }}</span></div>
           </div>
           <div class="mb-3">
@@ -91,7 +91,8 @@
           </div>
           <div class="mb-3">
             <label class="form-label">Num Major Vessels</label>
-            <input type="number" class="form-control" name="num_major_vessels" value="{{ baseline.num_major_vessels }}">
+            <input type="range" class="form-range" name="num_major_vessels" id="nmv" min="0" max="3" step="1" value="{{ baseline.num_major_vessels }}">
+            <div class="form-text"><span id="nmv-value">{{ baseline.num_major_vessels }}</span></div>
           </div>
           <div class="mb-3">
             <label class="form-label">Thalassemia Type</label>
@@ -105,21 +106,6 @@
         </div>
       </div>
 
-      <div class="row g-3 align-items-end">
-        <div class="col-md-6">
-          <label class="form-label">Variable</label>
-          <select class="form-select" name="variable" id="variable">
-            <option value="age">Age</option>
-            <option value="cholesterol">Cholesterol (mg/dL)</option>
-            <option value="resting_blood_pressure">Resting Blood Pressure (systolic mmHg)</option>
-            <option value="fasting_blood_sugar">Fasting Blood Sugar / Glucose (mg/dL)</option>
-            <option value="max_heart_rate_achieved">Max Heart Rate Achieved (bpm)</option>
-          </select>
-        </div>
-        <div class="col-md-6">
-          <button class="btn btn-brand w-100" id="run-sim">Run</button>
-        </div>
-      </div>
     </form>
   </div>
   <div class="col-lg-8 col-md-7">
@@ -129,6 +115,25 @@
     <div class="card">
       <div class="card-body">
         <div id="exercise-angina-chart" style="height:350px;"></div>
+      </div>
+    </div>
+    <div class="card mt-3">
+      <div class="card-body">
+        <div class="row g-3 align-items-end">
+          <div class="col-md-6">
+            <label class="form-label">Variable</label>
+            <select class="form-select" name="variable" id="variable">
+              <option value="age">Age</option>
+              <option value="cholesterol">Cholesterol (mg/dL)</option>
+              <option value="resting_blood_pressure">Resting Blood Pressure (systolic mmHg)</option>
+              <option value="fasting_blood_sugar">Fasting Blood Sugar / Glucose (mg/dL)</option>
+              <option value="max_heart_rate_achieved">Max Heart Rate Achieved (bpm)</option>
+            </select>
+          </div>
+          <div class="col-md-6">
+            <button class="btn btn-brand w-100" id="run-sim">Run</button>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/static/js/simulations.js
+++ b/static/js/simulations.js
@@ -1,7 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
   const runBtn = document.getElementById('run-sim');
   const form = document.getElementById('sim-form');
-  const inputs = form.querySelectorAll('input, select');
+  const variableSelect = document.getElementById('variable');
+  const inputs = [...form.querySelectorAll('input, select')];
+  if (variableSelect) {
+    inputs.push(variableSelect);
+  }
   let initialized = false;
 
   function updateSliderValue(id) {
@@ -12,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  ['age', 'bp', 'chol', 'fbs', 'mhr', 'st_dep'].forEach(id => {
+  ['age', 'bp', 'chol', 'fbs', 'mhr', 'st_dep', 'nmv'].forEach(id => {
     updateSliderValue(id);
     const el = document.getElementById(id);
     if (el) {
@@ -22,6 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function fetchSimulation() {
     const formData = new FormData(form);
+    if (variableSelect) {
+      formData.append('variable', variableSelect.value);
+    }
     return fetch('/simulations/run', {
       method: 'POST',
       body: formData


### PR DESCRIPTION
## Summary
- move variable selector and run button below chart
- limit ST Depression slider to 0-6.2 and add slider for Num Major Vessels (0-3)
- send variable selection with simulation requests and expose new ranges server-side

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb1182815c8327ae4ea7368bd549f8