### PR TITLE
Fix settings form macros to avoid TemplateSyntaxError

### DIFF
--- a/templates/components/forms.html
+++ b/templates/components/forms.html
@@ -1,23 +1,25 @@
-{% macro input(name, label, type='text', value='', **attrs) %}
+{% macro input(name, label, type='text', value='', attrs=None) %}
+{% set attrs = attrs or {} %}
 <div class="mb-3">
   <label class="form-label" for="{{ attrs.get('id', name) }}">{{ label }}</label>
   <input class="form-control" type="{{ type }}" name="{{ name }}" value="{{ value }}" {{ attrs|xmlattr }}>
 </div>
 {% endmacro %}
 
-{% macro text_input(name, label, value='', **attrs) %}
-  {{ input(name, label, type='text', value=value, **attrs) }}
+{% macro text_input(name, label, value='', attrs=None) %}
+  {{ input(name, label, type='text', value=value, attrs=attrs) }}
 {% endmacro %}
 
-{% macro email_input(name, label, value='', **attrs) %}
-  {{ input(name, label, type='email', value=value, **attrs) }}
+{% macro email_input(name, label, value='', attrs=None) %}
+  {{ input(name, label, type='email', value=value, attrs=attrs) }}
 {% endmacro %}
 
-{% macro password_input(name, label, **attrs) %}
-  {{ input(name, label, type='password', **attrs) }}
+{% macro password_input(name, label, attrs=None) %}
+  {{ input(name, label, type='password', attrs=attrs) }}
 {% endmacro %}
 
-{% macro file_input(name, label, **attrs) %}
+{% macro file_input(name, label, attrs=None) %}
+{% set attrs = attrs or {} %}
 <div class="mb-3">
   <label class="form-label" for="{{ attrs.get('id', name) }}">{{ label }}</label>
   <input class="form-control" type="file" name="{{ name }}" {{ attrs|xmlattr }}>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -25,9 +25,9 @@
       <div class="card-body">
         <form method="post" action="{{ url_for('settings.update_password') }}">
           <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-          {{ password_input('current_password', 'Current Password', autocomplete='off') }}
-          {{ password_input('new_password', 'New Password', id='new_password', autocomplete='new-password') }}
-          {{ password_input('confirm_password', 'Confirm New Password', id='confirm_password', autocomplete='new-password') }}
+            {{ password_input('current_password', 'Current Password', attrs={'autocomplete': 'off'}) }}
+            {{ password_input('new_password', 'New Password', attrs={'id': 'new_password', 'autocomplete': 'new-password'}) }}
+            {{ password_input('confirm_password', 'Confirm New Password', attrs={'id': 'confirm_password', 'autocomplete': 'new-password'}) }}
           <div id="password-match" class="small mt-2"></div>
           <button class="btn btn-brand" type="submit" id="password-submit" disabled>Update Password</button>
         </form>


### PR DESCRIPTION
## Summary
- Replace unsupported Jinja `**attrs` parameters with `attrs` dicts in form macros
- Adjust settings template to pass attributes via `attrs` for password fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bb1df46ab4832792ce231bacfe3a1a