### PR TITLE
Handle missing fasting blood sugar in batch predictions

### DIFF
--- a/app.py
+++ b/app.py
@@ -2289,10 +2289,12 @@ def upload_predict(uid: str):
     for _, row in df.iterrows():
         prob1 = None if pd.isna(row["positive_probability"]) else float(row["positive_probability"])
         conf = prob1 if int(row["prediction"]) == 1 else (1.0 - prob1) if prob1 is not None else 0.5
-        nmv = row.get("num_major_vessels")
-        nmv = int(nmv) if pd.notna(nmv) else None
-        fbs = row.get("fasting_blood_sugar")
-        fbs = int(fbs) if pd.notna(fbs) else None
+        def _int_or_none(value):
+            return int(value) if pd.notna(value) else None
+
+        nmv = _int_or_none(row.get("num_major_vessels"))
+        fbs = _int_or_none(row.get("fasting_blood_sugar"))
+        exang = _int_or_none(row.get("exercise_induced_angina"))
         pred = Prediction(
             patient_name=None,
             age=int(row["age"]),
@@ -2303,7 +2305,7 @@ def upload_predict(uid: str):
             fasting_blood_sugar=fbs,
             resting_ecg=str(row["Restecg"]),
             max_heart_rate=float(row["max_heart_rate_achieved"]),
-            exercise_angina=int(row["exercise_induced_angina"]),
+            exercise_angina=exang,
             oldpeak=float(row["st_depression"]),
             st_slope=str(row["st_slope_type"]),
             num_major_vessels=nmv,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 
 def test_upload_page(auth_client):
@@ -12,27 +13,34 @@ def test_upload_page(auth_client):
     assert response.status_code == 200
 
 
-def test_batch_prediction_handles_missing_fbs(auth_client):
+@pytest.mark.parametrize(
+    "missing_column, attr",
+    [
+        ("fasting_blood_sugar", "fasting_blood_sugar"),
+        ("exercise_induced_angina", "exercise_angina"),
+    ],
+)
+def test_batch_prediction_handles_missing_int_fields(auth_client, missing_column, attr):
     uid = uuid.uuid4().hex
     uploads_base = Path(auth_client.application.instance_path) / "uploads" / uid
     uploads_base.mkdir(parents=True, exist_ok=True)
-    df = pd.DataFrame(
-        {
-            "age": [63],
-            "sex": [1],
-            "chest_pain_type": ["typical_angina"],
-            "resting_blood_pressure": [145.0],
-            "cholesterol": [233.0],
-            "fasting_blood_sugar": [np.nan],
-            "Restecg": ["normal"],
-            "max_heart_rate_achieved": [150.0],
-            "exercise_induced_angina": [0],
-            "st_depression": [2.3],
-            "st_slope_type": ["upsloping"],
-            "num_major_vessels": [0],
-            "thalassemia_type": ["normal"],
-        }
-    )
+    data = {
+        "age": [63],
+        "sex": [1],
+        "chest_pain_type": ["typical_angina"],
+        "resting_blood_pressure": [145.0],
+        "cholesterol": [233.0],
+        "fasting_blood_sugar": [0],
+        "Restecg": ["normal"],
+        "max_heart_rate_achieved": [150.0],
+        "exercise_induced_angina": [0],
+        "st_depression": [2.3],
+        "st_slope_type": ["upsloping"],
+        "num_major_vessels": [0],
+        "thalassemia_type": ["normal"],
+    }
+    data[missing_column] = [np.nan]
+    df = pd.DataFrame(data)
     df.to_csv(uploads_base / "clean.csv", index=False)
     with auth_client.application.app_context():
         from app import Prediction, db
@@ -44,4 +52,4 @@ def test_batch_prediction_handles_missing_fbs(auth_client):
         after = Prediction.query.count()
         assert after == before + 1
         pred = Prediction.query.order_by(Prediction.id.desc()).first()
-        assert pred.fasting_blood_sugar is None
+        assert getattr(pred, attr) is None


### PR DESCRIPTION
## Summary
- Avoid ValueError when `fasting_blood_sugar` is NaN during batch upload predictions
- Add regression test covering missing fasting blood sugar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb35dee0a08327a3caccad859ec665