### PR TITLE
fix: remove extraneous endif in base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -72,7 +72,6 @@
               </a>
             </li>
             {% endif %}
-            {% endif %}
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" id="userMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 {% if current_user.avatar %}


### PR DESCRIPTION
## Summary
- ensure navbar dropdown is inside authenticated block

## Testing
- `pip install argon2-cffi` *(fails: Could not find a version that satisfies the requirement argon2-cffi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'cryptography'; No module named 'argon2')*

------
https://chatgpt.com/codex/tasks/task_b_68bbcf0dc088832f8177816901014956