### PR TITLE
feat: add persistent light/dark theme with chart theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Users can enter patient data, upload CSV files for batch analysis, explore resul
 - 🕵️ **Outlier Detection**: Batch EDA includes IQR, Isolation Forest, Z-Score, LOF, and DBSCAN methods to highlight anomalous records.
 - 📈 **EDA**: Cleaning log, summary statistics, and numeric correlation heatmap.
 - 🛡️ **Resilient Batch Prediction**: Handles missing `num_major_vessels` values without failing.
-
 - 🎨 **Modern UI**: Responsive Bootstrap 5 theme with custom colors, icons, and charts.
+- 🌗 **Light/Dark Theme**: Toggle via navbar, preference stored in localStorage/cookie with server-side rendering awareness. Charts adapt automatically with transparent backgrounds in dark mode.
 - 🔐 **Redesigned Login**: Clean layout without top navigation, centered branding and form, fields start empty with autofill disabled, password visibility toggle, hover animation on login button, and quick links.
 - 📌 **Sticky Footer**: Consistent footer on every page that stays at the bottom.
 - 🔒 **Safe by design**:
@@ -60,6 +60,18 @@ Roles are one of `SuperAdmin`, `Admin`, `Doctor`, or `User`.
 - **Frontend**: Jinja2 templates, Bootstrap 5, Plotly.js
 - **Reports**: ReportLab for PDF export
 - **Database**: SQLite (default)
+
+---
+
+## 🎨 UI Theming
+
+The application ships with a light theme by default. Users may toggle to a dark
+theme using the navbar button or from the **Settings** page. The preference is
+stored in `localStorage` and a cookie so server-rendered pages load in the
+correct mode with no flash. Plotly and Chart.js visualizations automatically
+adapt — in dark mode charts render on transparent backgrounds with updated text
+and grid colors. See [`docs/ui-theming.md`](docs/ui-theming.md) for guidance on
+extending theming.
 
 ---
 

--- a/TEST_CASES.md
+++ b/TEST_CASES.md
@@ -110,3 +110,9 @@
 | TC-053 | Password field eye icon toggles visibility on login page. | Authentication & Roles | 🟢 Low | 🧪 Functional | ⏳ Not Run |
 | TC-054 | Identifier field on login page starts empty without displaying "None". | Authentication & Roles | 🟢 Low | 🧪 Functional | ⏳ Not Run |
 | TC-055 | Login form disables autofill so fields remain blank. | Authentication & Roles | 🟢 Low | 🧪 Functional | ⏳ Not Run |
+
+## UI Theming
+| Test Case ID | Test Case Description | Module | Priority | Test Type | Status |
+| --- | --- | --- | --- | --- | --- |
+| TC-060 | Theme toggle updates `data-bs-theme`, cookie, and `localStorage` consistently. | UI Theming | 🟡 Medium | 🧪 Functional | ⏳ Not Run |
+| TC-061 | Server-side rendering respects `theme` cookie to avoid flash of incorrect theme. | UI Theming | 🟡 Medium | 🧪 Functional | ⏳ Not Run |

--- a/app.py
+++ b/app.py
@@ -71,6 +71,7 @@ from services.security import (
     get_csrf_token,
     csrf_protect_api,
 )
+from services.theme import init_theme
 
 from sqlalchemy import inspect, text
 
@@ -87,6 +88,9 @@ login_manager.login_view = "auth.login"
 
 password_hasher = PasswordHasher(time_cost=2, memory_cost=65536, parallelism=1, hash_len=32, salt_len=16)
 app.permanent_session_lifetime = timedelta(minutes=30)
+
+# Theme handling
+init_theme(app)
 
 # Ensure instance dir
 os.makedirs(app.instance_path, exist_ok=True)
@@ -897,6 +901,7 @@ from doctor import doctor_bp
 from user import user_bp
 from routes.settings import settings_bp
 from simulations import simulations_bp
+from routes.debug import debug_bp
 
 app.register_blueprint(predict_bp)
 app.register_blueprint(auth_bp)
@@ -905,6 +910,7 @@ app.register_blueprint(doctor_bp)
 app.register_blueprint(user_bp)
 app.register_blueprint(settings_bp)
 app.register_blueprint(simulations_bp)
+app.register_blueprint(debug_bp)
 
 
 @app.route("/admin/")
@@ -997,7 +1003,7 @@ def index():
         "num_major_vessels": 0,
         "thalassemia_type": "normal",
     }
-    return render_template("predict/form.html", defaults=defaults, model_name=model_name, theme="dark")
+    return render_template("predict/form.html", defaults=defaults, model_name=model_name)
 
 
 # ---------------------------

--- a/database.md
+++ b/database.md
@@ -2,6 +2,9 @@
 
 This document lists the tables in the application's database and includes `DESC` commands to inspect each table. Key columns are annotated to highlight primary keys (PK) and foreign keys (FK) linking related tables.
 
+User interface theme preferences are stored in client-side cookies and
+`localStorage`; no database tables persist this information.
+
 ## audit_log
 
 ```sql

--- a/docs/ui-theming.md
+++ b/docs/ui-theming.md
@@ -1,0 +1,18 @@
+# UI Theming
+
+HeartLytics supports light and dark color themes. The default is **light** and
+users can toggle using the navbar button or the setting on the Settings page.
+The selection is stored in `localStorage` and a long-lived `theme` cookie so the
+server can render pages in the correct theme without a flash of incorrect
+colors.
+
+## Usage
+
+No additional code is required to theme new Plotly or Chart.js charts. The
+`static/theme.charts.js` module patches the libraries globally so all charts pick
+up the current theme. In dark mode, chart backgrounds are transparent so they
+blend with the page.
+
+If a new visualization library is introduced, listen for the `themechange` event
+on `window` and apply colors from CSS variables such as `--bs-body-bg` and
+`--bs-body-color`.

--- a/gantt_chart.md
+++ b/gantt_chart.md
@@ -18,6 +18,7 @@ gantt
     Machine Learning Model          :         ml,   2024-02-15,2024-03-15
     Security & Encryption           :         sec,  2024-03-05,2024-03-25
     RBAC Hardening                  :         rbac, 2024-03-26,2024-04-05
+    UI Theming                     :         theme, 2024-04-06,2024-04-15
 
     section Testing
     Unit & Integration Tests        :         test, 2024-03-16,2024-03-31
@@ -32,7 +33,7 @@ gantt
 
 ## Summary
 - **Planning** ensures clear requirements and feasibility.
-- **Development** covers backend, frontend, and model building.
+- **Development** covers backend, frontend, model building, and UI theming.
 - **Testing** verifies functionality and user satisfaction.
 - **Deployment** marks the production release.
 - **Post-Deployment** includes monitoring and ongoing maintenance.

--- a/routes/debug.py
+++ b/routes/debug.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from flask import Blueprint, render_template
+from flask_login import login_required
+
+
+debug_bp = Blueprint("debug", __name__, url_prefix="/debug")
+
+
+@debug_bp.get("/theme")
+@login_required
+def theme_page():
+    """Simple page used as a smoke test for client-side theming."""
+    return render_template("debug/theme.html")

--- a/security_and_encryption.md
+++ b/security_and_encryption.md
@@ -28,6 +28,11 @@ This document summarizes the security controls implemented in the HeartLytics we
 ## Security Headers
 - Responses include headers like `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Permissions-Policy` to reduce attack surface.
 
+## Cookies
+- A `theme` preference cookie is stored for UI purposes only. It contains no
+  sensitive data and is sent with every request so the server can render the
+  correct color scheme.
+
 ## Encryption
 - HTTPS/TLS should be enforced in production to encrypt data in transit.
 - Sensitive configuration such as `SECRET_KEY` and database credentials are loaded from environment variables.

--- a/services/theme.py
+++ b/services/theme.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from flask import g, request
+
+def init_theme(app):
+    """Register hooks to expose the user's theme preference.
+
+    The theme is stored client-side via a cookie named ``theme``.  This
+    helper reads the cookie on each request and injects a ``theme`` template
+    variable so server-side rendering matches the user's preference and avoids
+    a flash of incorrect theme during page load.
+    """
+
+    @app.before_request
+    def _load_theme_from_cookie():
+        g.theme = request.cookies.get("theme", "light")
+
+    @app.context_processor
+    def _inject_theme():
+        return {"theme": getattr(g, "theme", "light")}

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,6 +7,7 @@
   --bs-secondary: #1e3a8a;
   --bs-body-bg: #f8fafc;
   --bs-body-color: #1f2937;
+  --bs-secondary-color: #64748b;
   --bs-link-color: var(--bs-secondary);
   --bs-link-hover-color: #1d4ed8;
   --bs-font-sans-serif: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
@@ -19,11 +20,17 @@
   --bs-border-color: #e5e7eb;
   --bs-card-bg: #fff;
   --bs-tertiary-bg: #f8f9fa;
+  --bs-success: #16a34a;
+  --bs-danger: #dc2626;
+  --bs-warning: #f59e0b;
+  --bs-info: #0ea5e9;
+  --border-subtle: #e2e8f0;
 }
 
 [data-bs-theme="dark"] {
   --bs-body-bg: #0f172a;
   --bs-body-color: #f1f5f9;
+  --bs-secondary-color: #94a3b8;
   --bs-link-color: #93c5fd;
   --bs-link-hover-color: #bfdbfe;
   --bs-border-color: #334155;
@@ -31,6 +38,11 @@
   --bs-tertiary-bg: #27303f;
   --bs-light: #374151;
   --brand-light: #450a0a;
+  --bs-success: #22c55e;
+  --bs-danger: #ef4444;
+  --bs-warning: #fbbf24;
+  --bs-info: #38bdf8;
+  --border-subtle: #475569;
 
 }
 

--- a/static/theme.charts.js
+++ b/static/theme.charts.js
@@ -1,0 +1,75 @@
+(function(){
+  function plotlyTheme(layout){
+    const root = document.documentElement;
+    const theme = root.getAttribute('data-bs-theme');
+    const styles = getComputedStyle(root);
+    const bodyColor = styles.getPropertyValue('--bs-body-color').trim();
+    const bodyBg = styles.getPropertyValue('--bs-body-bg').trim();
+    const border = styles.getPropertyValue('--border-subtle').trim() || styles.getPropertyValue('--bs-border-color').trim();
+    layout = Object.assign({
+      font: {family: 'Inter, sans-serif', color: bodyColor},
+      colorway: ['#dc2626', '#1e3a8a', '#f97316', '#0ea5e9', '#6366f1']
+    }, layout || {});
+    if (theme === 'dark'){
+      layout.paper_bgcolor = 'rgba(0,0,0,0)';
+      layout.plot_bgcolor = 'rgba(0,0,0,0)';
+    } else {
+      layout.paper_bgcolor = bodyBg;
+      layout.plot_bgcolor = bodyBg;
+    }
+    if (layout.xaxis){
+      layout.xaxis.color = bodyColor;
+      layout.xaxis.gridcolor = border;
+    }
+    if (layout.yaxis){
+      layout.yaxis.color = bodyColor;
+      layout.yaxis.gridcolor = border;
+    }
+    return layout;
+  }
+
+  function patchPlotly(){
+    if (!window.Plotly) return;
+    const orig = Plotly.newPlot;
+    Plotly.newPlot = function(id, data, layout, config){
+      layout = plotlyTheme(layout);
+      config = Object.assign({responsive: true, displayModeBar: false}, config || {});
+      return orig(id, data, layout, config);
+    };
+    window.addEventListener('themechange', () => {
+      document.querySelectorAll('.js-plotly-plot').forEach(el => {
+        const update = plotlyTheme({});
+        Plotly.relayout(el, update);
+      });
+    });
+  }
+
+  function chartJsTheme(){
+    if (!window.Chart) return;
+    function apply(){
+      const root = document.documentElement;
+      const styles = getComputedStyle(root);
+      const color = styles.getPropertyValue('--bs-body-color').trim();
+      const border = styles.getPropertyValue('--border-subtle').trim() || styles.getPropertyValue('--bs-border-color').trim();
+      Chart.defaults.color = color;
+      Chart.defaults.backgroundColor = 'transparent';
+      if (Chart.defaults.scales){
+        for (const s of Object.values(Chart.defaults.scales)){
+          s.grid = Object.assign({color: border}, s.grid || {});
+        }
+      }
+      if (Chart.defaults.plugins && Chart.defaults.plugins.legend){
+        Chart.defaults.plugins.legend.labels.color = color;
+      }
+    }
+    apply();
+    window.addEventListener('themechange', apply);
+  }
+
+  function init(){
+    patchPlotly();
+    chartJsTheme();
+  }
+  if (document.readyState !== 'loading') init();
+  else document.addEventListener('DOMContentLoaded', init);
+})();

--- a/static/theme.js
+++ b/static/theme.js
@@ -1,0 +1,54 @@
+(function(){
+  const STORAGE_KEY = 'theme';
+  const COOKIE_ATTRS = 'Path=/; Max-Age=31536000';
+
+  function applyTheme(theme){
+    const root = document.documentElement;
+    root.dataset.bsTheme = theme;
+    document.cookie = `theme=${theme}; ${COOKIE_ATTRS}`;
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta){
+      const bg = getComputedStyle(root).getPropertyValue('--bs-body-bg').trim();
+      meta.content = bg || '#ffffff';
+    }
+    const btn = document.getElementById('theme-toggle');
+    if (btn){
+      const icon = btn.querySelector('i');
+      if (icon){
+        icon.className = theme === 'dark' ? 'bi bi-sun-fill' : 'bi bi-moon-fill';
+      }
+    }
+  }
+
+  function setTheme(mode){
+    localStorage.setItem(STORAGE_KEY, mode);
+    const theme = mode === 'system'
+      ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+      : mode;
+    applyTheme(theme);
+    window.dispatchEvent(new Event('themechange'));
+  }
+
+  function toggleTheme(){
+    const current = document.documentElement.dataset.bsTheme;
+    setTheme(current === 'dark' ? 'light' : 'dark');
+  }
+
+  function init(){
+    setTheme(localStorage.getItem(STORAGE_KEY) || 'light');
+    const btn = document.getElementById('theme-toggle');
+    if (btn){
+      btn.addEventListener('click', toggleTheme);
+    }
+    // Expose for settings page
+    window.setTheme = setTheme;
+    if (window.matchMedia) {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+        if (localStorage.getItem(STORAGE_KEY) === 'system') setTheme('system');
+      });
+    }
+  }
+
+  if (document.readyState !== 'loading') init();
+  else document.addEventListener('DOMContentLoaded', init);
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#f8fafc">
     <title>{{ app_name }} - {% block title %}Heart Disease Risk{% endblock %}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -11,6 +12,8 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <script src="{{ url_for('static', filename='theme.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='theme.charts.js') }}" defer></script>
     {% block head %}{% endblock %}
   </head>
     <body class="d-flex flex-column min-vh-100">
@@ -101,7 +104,10 @@
             {% endif %}
           </ul>
         </div>
-        <div class="d-flex ms-auto align-items-center">
+        <div class="d-flex ms-auto align-items-center gap-2">
+          <button id="theme-toggle" class="btn btn-link nav-link" type="button" aria-label="Toggle color theme">
+            <i class="bi bi-moon-fill"></i>
+          </button>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav" aria-controls="nav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>
@@ -114,7 +120,7 @@
       {% block flashes %}
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
-          <div class="mb-3">
+          <div class="mb-3" aria-live="polite">
             {% for cat, msg in messages %}
               <div class="alert alert-{{ 'danger' if cat == 'error' else cat }} shadow-sm" role="alert">{{ msg }}</div>
             {% endfor %}
@@ -129,24 +135,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
-      (function () {
-        function brandPlotly() {
-          if (!window.Plotly) return;
-          const orig = Plotly.newPlot;
-          Plotly.newPlot = function (id, data, layout, config) {
-            layout = Object.assign({
-              font: {family: 'Inter, sans-serif'},
-              paper_bgcolor: 'white',
-              plot_bgcolor: '#f8fafc',
-              colorway: ['#dc2626', '#1e3a8a', '#f97316', '#0ea5e9', '#6366f1']
-            }, layout || {});
-            config = Object.assign({displayModeBar: false, responsive: true}, config || {});
-            return orig(id, data, layout, config);
-          };
-        }
-        if (document.readyState !== 'loading') brandPlotly();
-        else document.addEventListener('DOMContentLoaded', brandPlotly);
-      })();
       document.addEventListener('DOMContentLoaded', function() {
         const logoutLink = document.getElementById('logout-link');
         const logoutModalEl = document.getElementById('logoutModal');

--- a/templates/debug/theme.html
+++ b/templates/debug/theme.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block title %}Theme Debug{% endblock %}
+{% block content %}
+<h1>Theme Debug</h1>
+<p class="mb-3">Use the navbar toggle to switch themes. The tests below update live.</p>
+<ul id="debug-results" class="list-group"></ul>
+{% endblock %}
+{% block scripts %}
+{{ super() }}
+<script>
+function report(){
+  const list = document.getElementById('debug-results');
+  list.innerHTML = '';
+  const theme = document.documentElement.dataset.bsTheme;
+  const meta = document.querySelector('meta[name="theme-color"]').content;
+  const items = [
+    'data-bs-theme: ' + theme,
+    'localStorage.theme: ' + localStorage.getItem('theme'),
+    'cookie theme: ' + (document.cookie.match(/theme=([^;]+)/) || [])[1],
+    'meta theme-color: ' + meta
+  ];
+  items.forEach(t => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item';
+    li.textContent = t;
+    list.appendChild(li);
+  });
+}
+window.addEventListener('DOMContentLoaded', report);
+window.addEventListener('themechange', report);
+</script>
+{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -34,6 +34,18 @@
       </div>
     </div>
   </div>
+  <div class="col-md-6">
+    <div class="card shadow-sm">
+      <div class="card-header">Theme</div>
+      <div class="card-body">
+        <select id="theme-select" class="form-select" aria-label="Color theme">
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="system">System</option>
+        </select>
+      </div>
+    </div>
+  </div>
   {% if current_user.role == 'SuperAdmin' %}
   <div class="col-md-6">
     <div class="card shadow-sm">
@@ -91,6 +103,11 @@ document.addEventListener('DOMContentLoaded', function(){
   }
   np.addEventListener('input', check);
   cp.addEventListener('input', check);
+  const select = document.getElementById('theme-select');
+  if (select){
+    select.value = localStorage.getItem('theme') || 'light';
+    select.addEventListener('change', (e) => window.setTheme(e.target.value));
+  }
 });
 </script>
 {% endblock %}

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,3 @@
+def test_theme_cookie_ssr(auth_client):
+    resp = auth_client.get('/', headers={'Cookie': 'theme=dark'})
+    assert b'data-bs-theme="dark"' in resp.data


### PR DESCRIPTION
## Summary
- add server-aware theme persistence via cookie/localStorage and navbar toggle
- patch Plotly/Chart.js for automatic light/dark styles with transparent dark backgrounds
- document theming system and expose settings/debug pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'argon2')*


------
https://chatgpt.com/codex/tasks/task_b_68bbd37b097c832fb6926a74719f1613