### PR TITLE
fix: ensure MFA columns exist for user table

### DIFF
--- a/app.py
+++ b/app.py
@@ -783,6 +783,22 @@ with app.app_context():
         )
         db.session.commit()
 
+    # ensure MFA columns exist for older databases
+    for col, coltype in [
+        ("mfa_enabled", "BOOLEAN"),
+        ("mfa_secret_ct", "BLOB"),
+        ("mfa_secret_nonce", "BLOB"),
+        ("mfa_secret_tag", "BLOB"),
+        ("mfa_secret_wrapped_dk", "BLOB"),
+        ("mfa_secret_kid", "VARCHAR(64)"),
+        ("mfa_secret_kver", "INTEGER"),
+        ("mfa_recovery_hashes", "JSON"),
+        ("mfa_last_enforced_at", "DATETIME"),
+    ]:
+        if col not in user_cols:
+            db.session.execute(text(f"ALTER TABLE user ADD COLUMN {col} {coltype}"))
+            db.session.commit()
+
     # ensure default roles are present
     for name, perms in DEFAULT_ROLE_PERMISSIONS.items():
         if not Role.query.filter_by(role_name=name).first():


### PR DESCRIPTION
## Summary
- add startup migration to add MFA columns on legacy user tables

## Testing
- `pytest` *(fails: AttributeError: type object 'envelope' has no attribute 'encrypt_field'; IntegrityError in RBAC tests)*

------
https://chatgpt.com/codex/tasks/task_b_68bc203a21cc832fb592de0772f24be6