### PR TITLE
feat: add TOTP 2FA and require login after password reset

### DIFF
--- a/auth/mfa.py
+++ b/auth/mfa.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import secrets
+import re
 from flask import current_app, render_template, redirect, url_for, flash, session, request
 from flask_login import login_required, current_user, login_user
 
@@ -26,7 +27,8 @@ def mfa_setup():
     uri = provisioning_uri(secret, current_user.email, current_app.config.get("APP_NAME", "Heartlytics"))
     form = TOTPSetupForm()
     if form.validate_on_submit():
-        if verify_totp(secret, form.code.data.strip()):
+        code = re.sub(r"\s+", "", form.code.data)
+        if verify_totp(secret, code):
             current_user.set_mfa_secret(secret)
             codes = [secrets.token_hex(8) for _ in range(10)]
             current_user.mfa_recovery_hashes = [_hash_code(c) for c in codes]
@@ -74,7 +76,7 @@ def mfa_verify():
         return redirect(url_for("auth.login"))
     form = TOTPVerifyForm()
     if form.validate_on_submit():
-        code = form.code.data.strip()
+        code = re.sub(r"\s+", "", form.code.data)
         secret = user.mfa_secret
         if secret and verify_totp(secret, code):
             login_user(user)
@@ -109,7 +111,7 @@ def mfa_disable():
         if not current_user.check_password(form.password.data):
             flash("Invalid password", "error")
         else:
-            code = form.code.data.strip()
+            code = re.sub(r"\s+", "", form.code.data)
             secret = current_user.mfa_secret
             valid = secret and verify_totp(secret, code)
             hashed = _hash_code(code)


### PR DESCRIPTION
## Summary
- require users to sign in after resetting passwords and notify them of the change
- add TOTP-based two-step verification with recovery codes and encrypted secrets
- support prefilled identifiers on login and document new security options
- normalize MFA code input to strip whitespace and verify authenticator codes reliably
- extend MFA tests to cover codes containing spaces

## Testing
- `pytest tests/test_mfa.py -q`
- `pytest -q` *(fails: IntegrityError, assertion failures)*

------
https://chatgpt.com/codex/tasks/task_b_68bc56910f28832f81214f697c0cf06b