### PR TITLE
fix: strip separators from MFA codes

### DIFF
--- a/auth/forgot.py
+++ b/auth/forgot.py
@@ -8,6 +8,7 @@ import secrets
 import hashlib
 
 from flask import current_app, render_template, request, session, redirect, url_for, flash
+import re
 from sqlalchemy import or_
 
 from . import auth_bp
@@ -141,7 +142,8 @@ def verify_forgot():
             flash("Too many attempts. Request a new code.", "error")
             return redirect(url_for("auth.forgot"))
         pr.attempts += 1
-        if _hash_code(form.code.data.strip()) == pr.hashed_code:
+        code = re.sub(r"[^0-9A-Za-z]", "", form.code.data)
+        if _hash_code(code) == pr.hashed_code:
             pr.status = "verified"
             current_app.db.session.commit()
             session["pr_verified"] = True

--- a/auth/mfa.py
+++ b/auth/mfa.py
@@ -27,7 +27,7 @@ def mfa_setup():
     uri = provisioning_uri(secret, current_user.email, current_app.config.get("APP_NAME", "Heartlytics"))
     form = TOTPSetupForm()
     if form.validate_on_submit():
-        code = re.sub(r"\s+", "", form.code.data)
+        code = re.sub(r"[^0-9A-Za-z]", "", form.code.data)
         if verify_totp(secret, code):
             current_user.set_mfa_secret(secret)
             codes = [secrets.token_hex(8) for _ in range(10)]
@@ -76,7 +76,7 @@ def mfa_verify():
         return redirect(url_for("auth.login"))
     form = TOTPVerifyForm()
     if form.validate_on_submit():
-        code = re.sub(r"\s+", "", form.code.data)
+        code = re.sub(r"[^0-9A-Za-z]", "", form.code.data)
         secret = user.mfa_secret
         if secret and verify_totp(secret, code):
             login_user(user)
@@ -111,7 +111,7 @@ def mfa_disable():
         if not current_user.check_password(form.password.data):
             flash("Invalid password", "error")
         else:
-            code = re.sub(r"\s+", "", form.code.data)
+            code = re.sub(r"[^0-9A-Za-z]", "", form.code.data)
             secret = current_user.mfa_secret
             valid = secret and verify_totp(secret, code)
             hashed = _hash_code(code)


### PR DESCRIPTION
## Summary
- sanitize MFA inputs by removing non-alphanumeric characters
- normalize password-reset codes
- test TOTP and disable flows with dashed codes

## Testing
- `pytest`
- `pytest tests/test_mfa.py tests/test_forgot_password.py`


------
https://chatgpt.com/codex/tasks/task_b_68bc59f8bc34832fa17e039400a6795f