### PR TITLE
feat: enable email MFA by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Users can enter patient data, upload CSV files for batch analysis, explore resul
 - 🔐 **Redesigned Login**: Clean layout without top navigation, centered branding and form, fields start empty with autofill disabled, password visibility toggle, hover animation on login button, and quick links.
 - 🔑 **Forgot Password Flow**: Email verification code with enumeration-safe messaging; after reset, users re-authenticate with the new password.
 - 🔐 **TOTP 2-Step Verification**: Optional authenticator app codes with one-time recovery codes.
-- ✉️ **Email MFA Codes**: Optional single-use codes sent to your email as a fallback during login.
+- ✉️ **Email MFA Codes**: Enabled by default and sent as single-use backups when authenticator codes aren't available.
 - 📌 **Sticky Footer**: Consistent footer on every page that stays at the bottom.
 - 🧭 **Responsive Navigation**: Evenly spaced top bar with RBAC-driven items, sticky elevation, and utility icons.
 - 🎞️ **Motion System**: Tokenized durations/easings applied across components with `prefers-reduced-motion` support.

--- a/app.py
+++ b/app.py
@@ -356,7 +356,7 @@ class User(db.Model, UserMixin):
     last_login = db.Column(db.DateTime)
     avatar = db.Column(db.String(255))
     mfa_enabled = db.Column(db.Boolean, default=False)
-    mfa_email_enabled = db.Column(db.Boolean, default=False)
+    mfa_email_enabled = db.Column(db.Boolean, default=True)
     mfa_email_verified_at = db.Column(db.DateTime)
     mfa_secret_ct = db.Column(db.LargeBinary)
     mfa_secret_nonce = db.Column(db.LargeBinary)

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -158,7 +158,6 @@ def test_login_with_email_code(monkeypatch, client, app):
         user.mfa_enabled = True
         secret = random_base32()
         user.set_mfa_secret(secret)
-        user.mfa_email_enabled = True
         db.session.add(user)
         db.session.commit()
     monkeypatch.setattr("auth.mfa.secrets.choice", lambda seq: seq[0])


### PR DESCRIPTION
## Summary
- turn on email-based MFA codes by default for all users
- drop verification flow; enabling happens without codes
- document and test new default

## Testing
- `pytest tests/test_mfa.py::test_login_with_email_code -q`


------
https://chatgpt.com/codex/tasks/task_b_68bc61923120832f9590b674f6509cd1