### PR TITLE
docs: illustrate encryption flow

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -25,7 +25,7 @@ flowchart LR
     gen --> enc[Encrypt data]
     enc --> wrap[Wrap key with KMS]
     wrap --> store[Persist ciphertext and wrapped key]
-    store --> end([End])
+    store --> endNode([End])
 ```
 
 ## Design


### PR DESCRIPTION
## Summary
- visualize envelope encryption with data flow and BPMN diagrams

## Testing
- `pytest` *(fails: IntegrityError assertions and login tests)*

------
https://chatgpt.com/codex/tasks/task_b_68bd0df648e08332ad0a1634de3fa997