### PR TITLE
feat: redesign auth forgot password page

### DIFF
--- a/templates/_components/auth_card.html
+++ b/templates/_components/auth_card.html
@@ -1,0 +1,9 @@
+{% macro auth_card(title, subtitle=None) -%}
+<div class="card mx-auto" style="max-width:480px;">
+  <div class="card-body">
+    <h1 class="h4 mb-3">{{ title }}</h1>
+    {% if subtitle %}<p class="text-muted mb-4">{{ subtitle }}</p>{% endif %}
+    {{ caller() }}
+  </div>
+</div>
+{%- endmacro %}

--- a/templates/_components/buttons.html
+++ b/templates/_components/buttons.html
@@ -4,3 +4,7 @@
 {% macro secondary(text, attrs={}) -%}
   <button class="btn btn-secondary" {% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>{{ text }}</button>
 {%- endmacro %}
+{% macro link(text, attrs={}) -%}
+  {% set cls = attrs.pop('class', '') %}
+  <a class="btn btn-link {{ cls }}" {% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>{{ text }}</a>
+{%- endmacro %}

--- a/templates/_components/countdown_badge.html
+++ b/templates/_components/countdown_badge.html
@@ -1,0 +1,3 @@
+{% macro countdown_badge(time='00:00') -%}
+  <span class="badge bg-light text-muted" aria-live="polite">{{ time }}</span>
+{%- endmacro %}

--- a/templates/_components/form_field.html
+++ b/templates/_components/form_field.html
@@ -1,0 +1,10 @@
+{% macro form_field(name, label, type='text', value='', help=None, error=None, attrs={}) -%}
+  <div class="mb-3">
+    <label for="{{ name }}" class="form-label">{{ label }}</label>
+    <input type="{{ type }}" name="{{ name }}" id="{{ name }}" value="{{ value }}"
+           class="form-control{% if error %} is-invalid{% endif %}"
+           {% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>
+    {% if help %}<div class="form-text">{{ help }}</div>{% endif %}
+    {% if error %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
+  </div>
+{%- endmacro %}

--- a/templates/_components/otp_inputs.html
+++ b/templates/_components/otp_inputs.html
@@ -1,6 +1,11 @@
-{% macro otp_input(name='code', length=6) -%}
-  <div class="mb-3">
-    <label for="{{ name }}" class="form-label">6-digit code</label>
-    <input id="{{ name }}" name="{{ name }}" type="text" inputmode="numeric" maxlength="{{ length }}" class="form-control text-center otp-input" autocomplete="one-time-code" required>
+{% macro otp_inputs(name='code', length=6, label=None) -%}
+  {% if label %}<label class="form-label" for="{{ name }}1">{{ label }}</label>{% endif %}
+  <div class="d-flex justify-content-center gap-2 mb-3">
+    {% for i in range(length) %}
+      <input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1"
+             class="form-control text-center otp-input p-0"
+             style="width:44px;height:44px;" name="{{ name }}{{ i+1 }}" id="{{ name }}{{ i+1 }}"
+             aria-label="Digit {{ i+1 }}">
+    {% endfor %}
   </div>
 {%- endmacro %}

--- a/templates/auth/forgot.html
+++ b/templates/auth/forgot.html
@@ -1,18 +1,38 @@
 {% extends 'base.html' %}
-{% block title %}Find Your Account{% endblock %}
-{% from '_components/form.html' import text_input %}
-{% from '_components/buttons.html' import primary as primary_button %}
+{% block title %}Forgot Password{% endblock %}
+{% from '_components/auth_card.html' import auth_card %}
+{% from '_components/form_field.html' import form_field %}
+{% from '_components/otp_inputs.html' import otp_inputs %}
+{% from '_components/alerts.html' import render_flashes %}
+{% from '_components/countdown_badge.html' import countdown_badge %}
+{% import '_components/buttons.html' as btn %}
 {% block content %}
-<div class="card mx-auto" style="max-width:480px;">
-  <div class="card-body">
-    <h1 class="h4 mb-3">Find Your Account</h1>
-    <p>Please enter your email address or username to search for your account.</p>
-    <form method="post" autocomplete="off">
-      {{ form.hidden_tag() }}
-      {{ text_input('identifier', 'Email or Username', attrs={'required': ''}, error=form.identifier.errors[0] if form.identifier.errors else None) }}
-      {{ primary_button('Search') }}
-      <a href="{{ url_for('auth.login') }}" class="btn btn-secondary ms-2">Cancel</a>
-    </form>
+  {% set flashes = get_flashed_messages(with_categories=true) %}
+  {% call auth_card('Forgot your password?', 'Enter your email. We\u2019ll send a 6-digit code.') %}
+    {{ render_flashes(flashes) }}
+    {% if step == 'otp' %}
+      {{ form_field('email','Email', type='email', value=masked_email, attrs={'readonly':''}) }}
+      <hr class="my-4">
+      <p class="visually-hidden" aria-live="polite">Code sent to {{ masked_email }}</p>
+      <h2 class="h6 mb-3">Enter the 6-digit code sent to {{ masked_email }}</h2>
+      {{ otp_inputs('code') }}
+      <div class="d-flex align-items-center gap-2 mb-3">
+        {{ btn.secondary('Resend', {'type':'button','disabled':'disabled'}) }}
+        {{ countdown_badge('01:00') }}
+      </div>
+      <div class="mb-3">
+        {{ btn.link('Change email', {'href': url_for('auth.forgot'), 'class':'p-0 small'}) }}
+      </div>
+      {{ btn.primary('Continue') }}
+    {% else %}
+      <form method="post" autocomplete="off">
+        {{ form.hidden_tag() }}
+        {{ form_field('email','Email', type='email', help='We\u2019ll send a 6-digit code.', attrs={'placeholder':'name@example.com','required':'','autocomplete':'off'}) }}
+        {{ btn.primary('Continue', {'type':'submit'}) }}
+      </form>
+    {% endif %}
+  {% endcall %}
+  <div class="text-center mt-3">
+    <a href="{{ url_for('auth.login') }}">Back to Sign In</a>
   </div>
-</div>
 {% endblock %}

--- a/templates/auth/mfa_verify.html
+++ b/templates/auth/mfa_verify.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Two-Step Verification{% endblock %}
-{% from '_components/otp_inputs.html' import otp_input %}
+{% from '_components/otp_inputs.html' import otp_inputs %}
 {% from '_components/buttons.html' import primary as primary_button %}
 {% block content %}
 <div class="card mx-auto" style="max-width:480px;">
@@ -9,7 +9,7 @@
     <p class="mb-4">We sent a 6-digit code to {{ masked_email }}.</p>
     <form method="post" autocomplete="off">
       {{ form.hidden_tag() }}
-      {{ otp_input('code') }}
+      {{ otp_inputs('code', 6, '6-digit code') }}
       {{ primary_button('Verify') }}
     </form>
     {% if email_option %}


### PR DESCRIPTION
## Summary
- add reusable Jinja components for auth card, form fields, otp inputs, and countdown badge
- redesign forgot password flow with Bootstrap 5 UI
- extend buttons component with link style and update MFA verify to use segmented OTP inputs

## Testing
- `pytest -q --maxfail=1` *(fails: sqlite3 IntegrityError)*

------
https://chatgpt.com/codex/tasks/task_b_68bd8a1abb0c8332a484ac5082f0b193