### PR TITLE
Add missing settings controls and restore Admin landing access

### DIFF
--- a/app.py
+++ b/app.py
@@ -1169,7 +1169,7 @@ def api_delete_outliers():
 # ---------------------------
 @app.get("/")
 @login_required
-@require_roles("SuperAdmin", "Doctor", "User")
+@require_roles("SuperAdmin", "Admin", "Doctor", "User")
 def index():
     defaults = {
         "patient_name": "Demo Patient",

--- a/templates/_components/modal_upload.html
+++ b/templates/_components/modal_upload.html
@@ -1,22 +1,24 @@
 {% macro modal_upload(id, title) -%}
 <div class="modal fade" id="{{ id }}" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content">
+    <form class="modal-content" method="post" action="{{ url_for('settings.update_profile') }}" enctype="multipart/form-data">
       <div class="modal-header">
         <h5 class="modal-title">{{ title }}</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <input type="file" class="form-control mb-3" aria-label="Choose photo">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+        <label for="avatar" class="form-label">Choose photo</label>
+        <input type="file" name="avatar" id="avatar" class="form-control mb-3" aria-label="Choose photo">
         <div class="ratio ratio-1x1 border bg-light d-flex align-items-center justify-content-center">
           <span class="text-muted">Preview</span>
         </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary">Save</button>
+        <button type="submit" class="btn btn-primary">Save</button>
       </div>
-    </div>
+    </form>
   </div>
 </div>
 {%- endmacro %}

--- a/templates/settings/index.html
+++ b/templates/settings/index.html
@@ -31,6 +31,7 @@
           <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
           {{ form.text_input('username', 'Display Name', value=current_user.username) }}
           {{ form.text_input('email', 'Email', type='email', value=current_user.email, attrs={'readonly':'readonly'}) }}
+          {{ form.text_input('nickname', 'Nickname', value=current_user.nickname or '') }}
           <div class="mb-3">
             <button type="button" class="btn btn-link p-0" data-bs-toggle="modal" data-bs-target="#passwordModal">Change password</button>
           </div>
@@ -41,6 +42,41 @@
         </form>
       </div>
     </div>
+    <div class="card shadow-sm mb-4">
+      <div class="card-body d-flex justify-content-between align-items-center">
+        <div>
+          <h5 class="mb-0">Two-Step Verification</h5>
+          <small class="text-muted">{{ 'Enabled' if current_user.mfa_enabled else 'Available' }}</small>
+        </div>
+        <a href="{{ url_for('auth.mfa_setup') }}" class="btn btn-outline-secondary btn-sm">Manage</a>
+      </div>
+    </div>
+    <div class="card shadow-sm mb-4">
+      <div class="card-body d-flex justify-content-between align-items-center">
+        <div>
+          <h5 class="mb-0">Theme</h5>
+          <small class="text-muted">Dark mode</small>
+        </div>
+        <button id="theme-toggle-settings" class="btn btn-outline-secondary" type="button" aria-label="Toggle color theme">
+          <i class="bi bi-moon-fill"></i>
+        </button>
+      </div>
+    </div>
+    {% if current_user.role == 'SuperAdmin' %}
+    <div class="card shadow-sm mb-4">
+      <div class="card-body">
+        <form method="post" action="{{ url_for('settings.update_branding') }}" enctype="multipart/form-data">
+          <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+          {{ form.text_input('app_name', 'App Name', value=app_name) }}
+          <div class="mb-3">
+            <label for="logo" class="form-label">Upload Logo</label>
+            <input type="file" name="logo" id="logo" class="form-control">
+          </div>
+          {{ btn.primary('Save Branding', {'type':'submit'}) }}
+        </form>
+      </div>
+    </div>
+    {% endif %}
     <div class="card shadow-sm">
       <div class="card-header d-flex justify-content-between align-items-center">
         <span>Activity Log</span>
@@ -122,6 +158,22 @@ document.addEventListener('DOMContentLoaded', function(){
   }
   np.addEventListener('input', check);
   cp.addEventListener('input', check);
+  const themeBtn = document.getElementById('theme-toggle-settings');
+  if(themeBtn){
+    function updateThemeIcon(){
+      const icon = themeBtn.querySelector('i');
+      if(icon){
+        icon.className = document.documentElement.dataset.bsTheme === 'dark' ? 'bi bi-sun-fill' : 'bi bi-moon-fill';
+      }
+    }
+    themeBtn.addEventListener('click', () => {
+      const current = document.documentElement.dataset.bsTheme;
+      window.setTheme(current === 'dark' ? 'light' : 'dark');
+      updateThemeIcon();
+    });
+    window.addEventListener('themechange', updateThemeIcon);
+    updateThemeIcon();
+  }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Allow Admin role to view landing page
- Enable avatar uploads and add nickname, theme, 2FA, and branding controls to settings

## Testing
- `pytest -q` *(fails: IntegrityError, MFA, RBAC, simulations, theme)*

------
https://chatgpt.com/codex/tasks/task_b_68bd8c6c41e48332840182fc758abaa2