### PR TITLE
Enhance settings navigation and avatar display

### DIFF
--- a/static/js/settings-ui.js
+++ b/static/js/settings-ui.js
@@ -10,13 +10,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  const themeToggle = document.getElementById('theme-preview-toggle');
-  if (themeToggle) {
-    themeToggle.addEventListener('change', e => {
-      document.getElementById('theme-card').classList.toggle('theme-dark', e.target.checked);
-    });
-  }
-
   document.querySelectorAll('.toggle-password').forEach(btn => {
     btn.addEventListener('click', () => {
       const input = btn.previousElementSibling;
@@ -30,4 +23,8 @@ document.addEventListener('DOMContentLoaded', () => {
       input.focus();
     });
   });
+
+  if (document.body) {
+    new bootstrap.ScrollSpy(document.body, { target: '#settingsNav', offset: 100 });
+  }
 });

--- a/templates/settings/index.html
+++ b/templates/settings/index.html
@@ -4,14 +4,13 @@
 {% from '_components/modal_upload.html' import modal_upload %}
 {% from '_components/form_field.html' import form_field %}
 {% from '_components/password_group.html' import password_group %}
-{% from '_components/toggle.html' import theme_toggle %}
 {% from '_components/file_input.html' import file_input %}
 {% from '_components/badges.html' import badge %}
 {% from '_components/accordion.html' import log_accordion %}
 {% from '_components/table_toolbar.html' import table_toolbar %}
 {% block content %}
-<nav class="sticky-md-top border-bottom py-2 mb-4 d-none d-md-block bg-transparent">
-  <ul class="nav justify-content-center small">
+<nav id="settingsNav" class="sticky-top border-bottom py-2 mb-4 d-none d-md-block navbar bg-body" style="top:56px; z-index:1020;">
+  <ul class="nav justify-content-center small w-100">
     <li class="nav-item"><a class="nav-link" href="#account">Account</a></li>
     <li class="nav-item"><a class="nav-link" href="#security">Security</a></li>
     <li class="nav-item"><a class="nav-link" href="#customization">Customization</a></li>
@@ -22,7 +21,7 @@
   <aside class="col-md-4">
     <div class="card text-center">
       <div class="card-body">
-        {{ avatar(current_user.avatar_url or url_for('static', filename='avatars/None.jpg'), current_user.username) }}
+        {{ avatar(url_for('static', filename='avatars/' ~ (current_user.avatar or 'None.jpg')), current_user.username) }}
         <p class="fw-semibold mt-3 mb-0">{{ current_user.username }}</p>
         <p class="text-muted small mb-0">{{ current_user.email }}</p>
         <p class="text-muted small">{{ current_user.nickname }}</p>
@@ -30,7 +29,7 @@
     </div>
   </aside>
   <section class="col-md-8">
-    <div id="account" class="mb-5">
+    <div id="account" class="mb-5" style="scroll-margin-top:100px;">
       <div class="card mb-4">
         <div class="card-header"><h2 class="h6 mb-0">Account</h2></div>
         <form method="post" action="{{ url_for('settings.update_profile') }}" class="card-body p-4 position-relative">
@@ -38,7 +37,7 @@
           {{ form_field('text', 'username', 'Username', current_user.username, help='Visible to others.') }}
           {{ form_field('email', 'email', 'Email', current_user.email) }}
           {{ form_field('text', 'nickname', 'Nickname', current_user.nickname) }}
-          <div class="card-footer bg-body border-0 position-sticky bottom-0 d-flex justify-content-end gap-2">
+          <div class="card-footer bg-transparent border-0 position-sticky bottom-0 d-flex justify-content-end gap-2">
             <button type="reset" class="btn btn-secondary">Cancel</button>
             <button type="submit" class="btn btn-brand">Save</button>
           </div>
@@ -55,18 +54,8 @@
           </div>
         </form>
       </div>
-      <div class="card" id="theme-card">
-        <div class="card-header d-flex justify-content-between align-items-center">
-          <h2 class="h6 mb-0">Theme</h2>
-          <span class="badge bg-info text-dark">Preview</span>
-        </div>
-        <div class="card-body p-4">
-          {{ theme_toggle('theme-preview-toggle') }}
-          <div class="form-text">Changes here are illustrative and not saved.</div>
-        </div>
-      </div>
     </div>
-    <div id="security" class="mb-5">
+    <div id="security" class="mb-5" style="scroll-margin-top:100px;">
       <div class="card">
         <div class="card-header"><h2 class="h6 mb-0">Two-Step Verification</h2></div>
         <div class="card-body p-4">
@@ -87,7 +76,7 @@
       </div>
     </div>
     {% if current_user.role == 'SuperAdmin' %}
-    <div id="customization" class="mb-5">
+    <div id="customization" class="mb-5" style="scroll-margin-top:100px;">
       <div class="card">
         <div class="card-header"><h2 class="h6 mb-0">App Branding</h2></div>
         <form method="post" action="{{ url_for('settings.update_branding') }}" enctype="multipart/form-data" class="card-body p-4">
@@ -102,7 +91,7 @@
       </div>
     </div>
     {% endif %}
-    <div id="activity-log" class="mb-5">
+    <div id="activity-log" class="mb-5" style="scroll-margin-top:100px;">
       <div class="card">
         <div class="card-header"><h2 class="h6 mb-0">Activity Log</h2></div>
         <div class="card-body p-4">


### PR DESCRIPTION
## Summary
- Add sticky ScrollSpy nav for Settings sections
- Show logged-in user's avatar in profile panel
- Remove theme preview card and make account footer transparent
- Initialize ScrollSpy in settings UI script

## Testing
- `pytest` (fails: tests/test_rbac.py::test_nav_visibility[Admin-shows1], tests/test_rbac.py::test_nav_visibility[User-shows3], tests/test_rbac.py::test_api_json_denied, tests/test_simulations.py::test_simulations_page, tests/test_theme.py::test_theme_cookie_ssr)


------
https://chatgpt.com/codex/tasks/task_b_68bd9f41c4e08332ae3e8d8691bc9349