### PR TITLE
fix: submit otp and restore resend

### DIFF
--- a/templates/_components/otp_inputs.html
+++ b/templates/_components/otp_inputs.html
@@ -3,20 +3,25 @@
   {% for i in range(length) %}
   <input type="text" inputmode="numeric" pattern="[0-9]*" maxlength="1" class="form-control text-center" style="width:3rem;height:3rem;" id="{{ name }}{{ i }}" name="{{ name }}{{ i }}" aria-label="Digit {{ i + 1 }}">
   {% endfor %}
+  <input type="hidden" name="{{ name }}" id="{{ name }}">
 </div>
 <script>
 document.addEventListener('DOMContentLoaded',()=>{
   document.querySelectorAll('[data-otp-group]').forEach(group=>{
-    const inputs=group.querySelectorAll('input');
+    const inputs=group.querySelectorAll('input[type="text"]');
+    const hidden=group.querySelector('input[type="hidden"]');
+    const updateHidden=()=>{hidden.value=Array.from(inputs).map(i=>i.value).join('');};
     inputs.forEach((inp,idx)=>{
       inp.addEventListener('input',e=>{
         if(e.target.value.length===1 && idx<inputs.length-1){inputs[idx+1].focus();}
+        updateHidden();
       });
     });
     group.addEventListener('paste',e=>{
       const data=e.clipboardData.getData('text').replace(/\D/g,'').slice(0,inputs.length);
       data.split('').forEach((ch,i)=>{inputs[i].value=ch;});
       inputs[Math.min(data.length,inputs.length-1)].focus();
+      updateHidden();
       e.preventDefault();
     });
   });

--- a/templates/auth/verify.html
+++ b/templates/auth/verify.html
@@ -18,9 +18,27 @@
       {{ primary_button('Continue', attrs={'type':'submit'}) }}
     </form>
     <div class="d-flex align-items-center gap-2 mt-3">
-      {{ secondary_button('Resend', attrs={'disabled':''}) }}
+      <form method="post" action="{{ url_for('auth.resend_code') }}" id="resend-form">
+        {{ secondary_button('Resend', attrs={'type':'submit','id':'resend-btn','disabled':''}) }}
+      </form>
       {{ countdown_badge('%02d:%02d'|format(cooldown//60, cooldown%60)) }}
     </div>
+    <script>
+    document.addEventListener('DOMContentLoaded',()=>{
+      const btn=document.getElementById('resend-btn');
+      const badge=document.getElementById('countdown');
+      let remaining={{ cooldown }};
+      if(remaining<=0){btn.removeAttribute('disabled');badge.style.display='none';return;}
+      const tick=()=>{
+        remaining--;
+        const m=String(Math.floor(remaining/60)).padStart(2,'0');
+        const s=String(remaining%60).padStart(2,'0');
+        badge.textContent=`${m}:${s}`;
+        if(remaining<=0){clearInterval(int);btn.removeAttribute('disabled');badge.style.display='none';}
+      };
+      const int=setInterval(tick,1000);
+    });
+    </script>
     <p class="mt-3"><a href="{{ url_for('auth.forgot') }}" class="link-secondary">Change email</a></p>
     <div class="mt-4 text-center">
       {{ link_button('Back to Sign In', url_for('auth.login')) }}


### PR DESCRIPTION
## Summary
- capture segmented OTP digits into hidden field for validation
- rehook resend button with countdown to reissue codes

## Testing
- `pytest` *(fails: test_nav_visibility[Admin-shows1], test_nav_visibility[User-shows3], test_api_json_denied, test_simulations_page, test_theme_cookie_ssr)*

------
https://chatgpt.com/codex/tasks/task_b_68bdd101c5948332ac8b2243ae5659b7