### PR TITLE
Fix signup notification and field handling

### DIFF
--- a/static/js/signup.js
+++ b/static/js/signup.js
@@ -15,9 +15,9 @@ document.addEventListener('DOMContentLoaded', () => {
       /[A-Z]/.test(val),
       /[a-z]/.test(val),
       /\d/.test(val),
-      /[^A-Za-z0-9]/.test(val)
-    ].filter(Boolean).length;
-  }
+        /[!@#$%^&*]/.test(val)
+      ].filter(Boolean).length;
+    }
 
   function updateStrength() {
     const val = passwordInput.value;

--- a/templates/_components/form_field.html
+++ b/templates/_components/form_field.html
@@ -1,15 +1,21 @@
 {% macro form_field(type, name, label, value='', help='', error=None, attrs={}, password_toggle=False, error_hidden=False) -%}
-<div class="mb-3" id="{{ name }}-field">
-  <label for="{{ name }}" class="form-label">{{ label }}</label>
-  {% if password_toggle %}
-  <div class="input-group">
-    <input type="{{ type }}" class="form-control{% if error %} is-invalid{% endif %}" id="{{ name }}" name="{{ name }}" value="{{ value }}"{% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>
-    <button class="btn btn-outline-secondary password-toggle" type="button" tabindex="-1" aria-label="Show password"><i class="bi bi-eye"></i></button>
+  <div class="mb-3" id="{{ name }}-field">
+    <label for="{{ name }}" class="form-label">{{ label }}</label>
+    {% set input_attrs = 'type="' ~ type ~ '" class="form-control' ~ (error and ' is-invalid' or '') ~ '" id="' ~ name ~ '" name="' ~ name ~ '" value="' ~ value ~ '"' %}
+    {% if attrs %}
+    {% for k,v in attrs.items() %}
+    {% set input_attrs = input_attrs ~ ' ' ~ k ~ '="' ~ v ~ '"' %}
+    {% endfor %}
+    {% endif %}
+    {% if password_toggle %}
+    <div class="input-group">
+      <input {{ input_attrs|safe }}>
+      <button class="btn btn-outline-secondary password-toggle" type="button" tabindex="-1" aria-label="Show password"><i class="bi bi-eye"></i></button>
+    </div>
+    {% else %}
+    <input {{ input_attrs|safe }}>
+    {% endif %}
+    {% if help %}<div class="form-text text-muted">{{ help }}</div>{% endif %}
+    {% if error %}<div class="invalid-feedback{% if error_hidden %} d-none{% endif %}">{{ error }}</div>{% endif %}
   </div>
-  {% else %}
-  <input type="{{ type }}" class="form-control{% if error %} is-invalid{% endif %}" id="{{ name }}" name="{{ name }}" value="{{ value }}"{% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>
-  {% endif %}
-  {% if help %}<div class="form-text text-muted">{{ help }}</div>{% endif %}
-  {% if error %}<div class="invalid-feedback{% if error_hidden %} d-none{% endif %}">{{ error }}</div>{% endif %}
-</div>
-{%- endmacro %}
+  {%- endmacro %}

--- a/templates/auth/signup.html
+++ b/templates/auth/signup.html
@@ -29,11 +29,11 @@
           <div class="mt-3">
             <span class="text-muted">Already have an account?</span> <a href="{{ url_for('auth.login') }}">Sign In</a>
           </div>
-          <input type="hidden" name="role" value="User">
-          {{ form.nickname(size=0, style='display:none') }}
-        </form>
-      {% endcall %}
-    </div>
+            <input type="hidden" name="role" value="User">
+            {{ form.nickname(size=0, class='d-none') }}
+          </form>
+        {% endcall %}
+      </div>
     <div class="col-md-6 order-1 order-md-2 d-md-flex align-items-center justify-content-center bg-body-secondary p-4">
       <div class="d-none d-md-block">
         <h2 class="h5 mb-3">Why join HeartLytics?</h2>
@@ -45,10 +45,12 @@
       </div>
     </div>
   </div>
-  <div class="toast-container position-fixed top-0 end-0 p-3" aria-live="polite" aria-atomic="true">
-    <div class="toast show"><div class="toast-body">Account created — check your email</div></div>
-  </div>
-{% endblock %}
+    {% if account_created %}
+    <div class="toast-container position-fixed top-0 end-0 p-3" aria-live="polite" aria-atomic="true">
+      <div class="toast show"><div class="toast-body">Account created — check your email</div></div>
+    </div>
+    {% endif %}
+  {% endblock %}
 
 {% block scripts %}
   <script src="{{ url_for('static', filename='js/auth.js') }}"></script>


### PR DESCRIPTION
## Summary
- Show signup success toast only after account creation
- Hide honeypot nickname field with Bootstrap class
- Restrict password strength regex to required special characters
- Refactor form_field macro to eliminate duplicate input markup

## Testing
- `pytest` *(fails: tests/test_rbac.py::test_nav_visibility[Admin-shows1], tests/test_rbac.py::test_nav_visibility[User-shows3], tests/test_api_json_denied, tests/test_simulations.py::test_simulations_page, tests/test_theme.py::test_theme_cookie_ssr)*

------
https://chatgpt.com/codex/tasks/task_b_68bddc2fedb883328e21a62e2b84663c