### PR TITLE
Add email verification to signup and secure form macro

### DIFF
--- a/app.py
+++ b/app.py
@@ -354,6 +354,7 @@ class User(db.Model, UserMixin):
         onupdate=lambda: datetime.now(timezone.utc),
     )
     last_login = db.Column(db.DateTime)
+    email_verified_at = db.Column(db.DateTime)
     avatar = db.Column(db.String(255))
     mfa_enabled = db.Column(db.Boolean, default=False)
     mfa_email_enabled = db.Column(db.Boolean, default=True)
@@ -475,6 +476,22 @@ class PasswordResetRequest(db.Model):
     expires_at = db.Column(db.DateTime, nullable=False)
     attempts = db.Column(db.Integer, nullable=False, default=0)
     resend_count = db.Column(db.Integer, nullable=False, default=0)
+    last_sent_at = db.Column(db.DateTime, nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="pending")
+    requester_ip = db.Column(db.String(45))
+    user_agent = db.Column(db.String(200))
+
+    user = db.relationship("User")
+
+
+class EmailVerification(db.Model):
+    """Email verification codes issued during signup."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
+    code_hash = db.Column(db.String(64), nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+    attempts = db.Column(db.Integer, nullable=False, default=0)
     last_sent_at = db.Column(db.DateTime, nullable=False)
     status = db.Column(db.String(20), nullable=False, default="pending")
     requester_ip = db.Column(db.String(45))
@@ -728,6 +745,7 @@ app.ClusterSummary = ClusterSummary
 app.AuditLog = AuditLog
 app.PasswordResetRequest = PasswordResetRequest
 app.MFAEmailChallenge = MFAEmailChallenge
+app.EmailVerification = EmailVerification
 app.Role = Role
 app.UserRole = UserRole
 app.Patient = Patient

--- a/docs/2-step-verification.md
+++ b/docs/2-step-verification.md
@@ -43,7 +43,7 @@ Security features include hashed OTP storage with pepper, rate limiting on resen
 
 The forgot-password interface uses a compact authentication card with segmented six-box code inputs and Bootstrap 5 components. Each box auto-advances on input and accepts pasted codes across all fields. A muted countdown badge visually indicates when the disabled resend button will become active.
 
-The redesigned sign-up flow includes an optional email verification card that reuses these segmented inputs to keep the experience consistent.
+The redesigned sign-up flow now requires an email verification card that reuses these segmented inputs to keep the experience consistent.
 
 ## Detailed Data Flow Diagram (DFD)
 

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -23,6 +23,7 @@
 | TC-085 | Countdown badge shows mm:ss while resend is disabled. | Authentication & Roles | 🟢 Low | 🧪 Functional | ⏳ Not Run |
 | TC-086 | Signup button stays disabled until form fields are valid. | Authentication & Roles | 🟢 Low | 🧪 Functional | ⏳ Not Run |
 | TC-087 | Password strength meter reflects complexity rules. | Authentication & Roles | 🟢 Low | 🧪 Functional | ⏳ Not Run |
+| TC-088 | Signup requires email verification before login. | Authentication & Roles | 🔴 High | 🔒 Security | ⏳ Not Run |
 | TC-073 | `/debug/mail` sends test email and lists recent events. | Authentication & Roles | 🟢 Low | 🧪 Functional | ⏳ Not Run |
 | TC-074 | Password reset requires re-login; no automatic session. | Authentication & Roles | 🔴 High | 🔒 Security | ⏳ Not Run |
 | TC-075 | User with TOTP enabled must enter valid code after password. | Authentication & Roles | 🔴 High | 🔒 Security | ⏳ Not Run |

--- a/docs/database.md
+++ b/docs/database.md
@@ -15,7 +15,7 @@ entirely on the client and do not impact the database schema.
 The password reset feature introduces a `password_reset_request` table storing short-lived verification codes.
 Email-based MFA uses an `mfa_email_challenge` table recording hashed codes, attempts, and resend timestamps.
 The redesigned forgot-password interface and segmented OTP inputs are client-side only and do not alter the database schema.
-The new sign-up page with password strength checks and optional email verification likewise introduces no additional tables or columns.
+The new sign-up flow requires email verification, adding an `email_verification` table for pending codes and an `email_verified_at` column on `user`.
 
 ## audit_log
 
@@ -74,6 +74,24 @@ DESC password_reset_request;
 | user_agent | VARCHAR(200) |  |  |
 
 Requests expire after 10 minutes and are stored as SHA-256 hashes with a server-side pepper. Submitted codes are verified using constant-time comparisons to prevent timing attacks.
+
+## email_verification
+
+```sql
+DESC email_verification;
+```
+
+| Column | Type | Key | References |
+| --- | --- | --- | --- |
+| id | INTEGER | PK | - |
+| user_id | INTEGER | FK | user.id |
+| code_hash | VARCHAR(64) |  |  |
+| expires_at | DATETIME |  |  |
+| attempts | INTEGER |  |  |
+| last_sent_at | DATETIME |  |  |
+| status | VARCHAR(20) |  |  |
+| requester_ip | VARCHAR(45) |  |  |
+| user_agent | VARCHAR(200) |  |  |
 
 ## patient
 
@@ -164,6 +182,7 @@ DESC user;
 | created_at | DATETIME |  |  |
 | updated_at | DATETIME |  |  |
 | last_login | DATETIME |  |  |
+| email_verified_at | DATETIME |  |  |
 | avatar | VARCHAR(255) |  |  |
 | mfa_enabled | BOOLEAN |  |  |
 | mfa_email_enabled | BOOLEAN |  |  |

--- a/docs/forget_password.md
+++ b/docs/forget_password.md
@@ -16,7 +16,7 @@ encryption details see [Security and Encryption](security_and_encryption.md).
   to cooldown and attempt limits.
 
 The UI presents the flow in a single Bootstrap authentication card. The first step collects an email address with helper text. After submission, a subtle divider reveals a six‑box OTP entry interface with auto‑tab and paste support. A disabled resend button is paired with a muted mm:ss countdown badge and a link to change the email if necessary.
-The same segmented OTP component now powers optional email verification after account creation, providing a consistent experience.
+The same segmented OTP component now powers mandatory email verification after account creation, providing a consistent experience.
 
 ## BPMN 2.0
 

--- a/docs/gantt_chart.md
+++ b/docs/gantt_chart.md
@@ -41,7 +41,7 @@ gantt
 - Latest update introduces server-side masked OTP emails and resend countdowns.
 - Latest update introduces an email-based forgot password flow with OTP verification.
 - Latest update introduces a spaced, role-aware navigation bar and a shared motion token system.
-- Latest update redesigns the sign-up page with a strength meter and email verification card.
+- Latest update redesigns the sign-up page with a strength meter and mandatory email verification card.
 - Latest update redesigns the forgot-password page with a Bootstrap card, segmented OTP inputs, and a visual resend countdown.
 - Simulations now feature inline auto-update feedback with subtle loader and timestamped confirmation.
 - Forgot-password emails now send via Gmail SMTP with `/debug/mail` diagnostics and rate-limited OTP handling.

--- a/docs/research_paper.md
+++ b/docs/research_paper.md
@@ -25,6 +25,7 @@ Recent work shows strong performance for supervised ML models in heart disease p
 7. Provide fallback email-based one-time codes as a lower-assurance MFA option.
 8. Mask destination emails during verification to protect user privacy.
 9. Redesign the forgot-password interface using Bootstrap 5 cards and segmented OTP inputs for improved accessibility.
+10. Require email verification during sign-up before account use.
 
 ## Dataset and Exploratory Data Analysis (EDA)
 

--- a/docs/security_and_encryption.md
+++ b/docs/security_and_encryption.md
@@ -17,7 +17,7 @@ links to the dedicated [Forgot Password / 2‑Step Verification flow](forget_pas
 - Login, OTP request, and verification endpoints enforce per‑IP and per‑ID
   limits to deter brute force attempts.
 - Redesigned forgot-password page uses segmented OTP inputs and a visible countdown badge without exposing full email addresses.
-- Sign-up form features a client-side password strength meter and optional email verification using the same OTP component.
+- Sign-up form features a client-side password strength meter and requires email verification using the same OTP component.
 
 ## Authorization
 

--- a/docs/thesis.md
+++ b/docs/thesis.md
@@ -627,7 +627,7 @@ def test_login_with_email_code(monkeypatch, client, app):
 Running `pytest` executes these tests to confirm encryption integrity, MFA verification, recovery code handling and email fallback functionality.
 
 ## Timeline and Project Management
-The project followed a structured Gantt plan spanning planning, development, testing and deployment phases with milestones such as Security & Encryption, RBAC Hardening, MFA rollout and UI Theming. Recent iterations added a redesigned sign-up page with strength-based password guidance and an email verification step. Post‑deployment monitoring extends into maintenance.
+The project followed a structured Gantt plan spanning planning, development, testing and deployment phases with milestones such as Security & Encryption, RBAC Hardening, MFA rollout and UI Theming. Recent iterations added a redesigned sign-up page with strength-based password guidance and a mandatory email verification step. Post‑deployment monitoring extends into maintenance.
 
 ## Ethics, Privacy, and Compliance
 HeartLytics minimizes data retention and encrypts sensitive fields. Cookies store only non‑sensitive theme preferences; sessions timeout to reduce exposure. The system adheres to OWASP guidelines and enables cryptographic erasure via KMS key deletion. Deployments targeting EU residents must ensure GDPR compliance, user consent and breach notification procedures.

--- a/docs/ui-theming.md
+++ b/docs/ui-theming.md
@@ -17,4 +17,4 @@ If a new visualization library is introduced, listen for the `themechange` event
 on `window` and apply colors from CSS variables such as `--bs-body-bg` and
 `--bs-body-color`.
 
-Auth pages, including the redesigned sign-up and forgot-password flows, consume reusable Bootstrap components so card backgrounds, buttons, and countdown badges adapt automatically to the selected theme.
+Auth pages, including the redesigned sign-up, email verification, and forgot-password flows, consume reusable Bootstrap components so card backgrounds, buttons, and countdown badges adapt automatically to the selected theme.

--- a/services/mfa.py
+++ b/services/mfa.py
@@ -46,3 +46,24 @@ def send_reset_email(user, code: str, ttl: int, request) -> None:
     except Exception as exc:  # pragma: no cover - network errors
         current_app.logger.error("otp.email.failed user=%s", user.email, exc_info=exc)
 
+
+def send_signup_email(user, code: str, ttl: int, request) -> None:
+    """Send a signup verification ``code`` to ``user`` via email."""
+
+    text = (
+        f"Your verification code is {code}.\n"
+        f"It expires in {ttl} minutes.\n"
+        f"Request time: {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}\n"
+        f"IP: {request.remote_addr}\n"
+        "If this wasn't you, ignore this message."
+    )
+    html = text.replace("\n", "<br>")
+    try:
+        current_app.email_service.send_mail(
+            user.email, "Verify your email", text, html, purpose="signup_verify"
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        current_app.logger.error(
+            "signup.email.failed user=%s", user.email, exc_info=exc
+        )
+

--- a/templates/_components/form_field.html
+++ b/templates/_components/form_field.html
@@ -1,21 +1,16 @@
 {% macro form_field(type, name, label, value='', help='', error=None, attrs={}, password_toggle=False, error_hidden=False) -%}
   <div class="mb-3" id="{{ name }}-field">
     <label for="{{ name }}" class="form-label">{{ label }}</label>
-    {% set input_attrs = 'type="' ~ type ~ '" class="form-control' ~ (error and ' is-invalid' or '') ~ '" id="' ~ name ~ '" name="' ~ name ~ '" value="' ~ value ~ '"' %}
-    {% if attrs %}
-    {% for k,v in attrs.items() %}
-    {% set input_attrs = input_attrs ~ ' ' ~ k ~ '="' ~ v ~ '"' %}
-    {% endfor %}
-    {% endif %}
+    {% set classes = 'form-control' + (error and ' is-invalid' or '') %}
     {% if password_toggle %}
     <div class="input-group">
-      <input {{ input_attrs|safe }}>
+      <input type="{{ type }}" class="{{ classes }}" id="{{ name }}" name="{{ name }}" value="{{ value }}"{% for k,v in attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
       <button class="btn btn-outline-secondary password-toggle" type="button" tabindex="-1" aria-label="Show password"><i class="bi bi-eye"></i></button>
     </div>
     {% else %}
-    <input {{ input_attrs|safe }}>
+    <input type="{{ type }}" class="{{ classes }}" id="{{ name }}" name="{{ name }}" value="{{ value }}"{% for k,v in attrs.items() %} {{ k }}="{{ v }}"{% endfor %}>
     {% endif %}
     {% if help %}<div class="form-text text-muted">{{ help }}</div>{% endif %}
     {% if error %}<div class="invalid-feedback{% if error_hidden %} d-none{% endif %}">{{ error }}</div>{% endif %}
   </div>
-  {%- endmacro %}
+{%- endmacro %}

--- a/templates/auth/signup_verify.html
+++ b/templates/auth/signup_verify.html
@@ -16,6 +16,7 @@
   {% call auth_card('Verify your email') %}
     <p class="text-muted mb-3">Enter the 6-digit code sent to your email address.</p>
     <form method="post" autocomplete="off" novalidate>
+      {{ form.hidden_tag() }}
       {{ otp_inputs('code') }}
       {{ primary_button('Verify', attrs={'type':'submit'}) }}
     </form>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import types
 import pytest
 import os
 import base64
+from datetime import datetime
 
 # Provide a minimal stub for `python-dotenv` if the package isn't installed.
 # This avoids import errors during tests when the optional dependency is missing.
@@ -54,6 +55,7 @@ def auth_client(client):
             user = User(username="tester", email="t@example.com", role="Doctor", status="approved")
             db.session.add(user)
         user.password_hash = generate_password_hash("testpass")
+        user.email_verified_at = datetime.utcnow()
         db.session.commit()
 
     client.post(
@@ -81,6 +83,7 @@ def superadmin_client(client):
             )
             db.session.add(user)
         user.password_hash = generate_password_hash("sapass")
+        user.email_verified_at = datetime.utcnow()
         db.session.commit()
 
     client.post(

--- a/tests/test_encrypted_fields.py
+++ b/tests/test_encrypted_fields.py
@@ -1,10 +1,14 @@
 from app import db, Patient, User
+from datetime import datetime
 
 
 def test_patient_encryption_round_trip(app):
     app.config["ENCRYPTION_ENABLED"] = True
     with app.app_context():
+        User.query.filter_by(email="u1@example.com").delete()
+        db.session.commit()
         user = User(username="u1", email="u1@example.com", role="Doctor", status="approved")
+        user.email_verified_at = datetime.utcnow()
         db.session.add(user)
         db.session.commit()
         p = Patient(entered_by_user_id=user.id)

--- a/tests/test_forgot_password.py
+++ b/tests/test_forgot_password.py
@@ -1,4 +1,5 @@
 from werkzeug.security import generate_password_hash
+from datetime import datetime
 
 
 def _create_user(app, username="user1", email="u1@example.com"):
@@ -8,6 +9,7 @@ def _create_user(app, username="user1", email="u1@example.com"):
         if not user:
             user = User(username=username, email=email, status="approved")
             user.password_hash = generate_password_hash("oldpass")
+            user.email_verified_at = datetime.utcnow()
             db.session.add(user)
             db.session.commit()
     return user

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -1,6 +1,7 @@
 import secrets
 from werkzeug.security import generate_password_hash
 from auth.totp import random_base32, generate_totp
+from datetime import datetime
 
 
 def test_login_with_totp(client, app):
@@ -9,6 +10,7 @@ def test_login_with_totp(client, app):
         User.query.filter_by(email="mfa@example.com").delete()
         db.session.commit()
         user = User(username="mfauser", email="mfa@example.com", status="approved")
+        user.email_verified_at = datetime.utcnow()
         user.password_hash = generate_password_hash("Passw0rd!")
         user.mfa_enabled = True
         secret = random_base32()
@@ -37,6 +39,7 @@ def test_login_with_totp_spaces(client, app):
         User.query.filter_by(email="mfa3@example.com").delete()
         db.session.commit()
         user = User(username="mfauser3", email="mfa3@example.com", status="approved")
+        user.email_verified_at = datetime.utcnow()
         user.password_hash = generate_password_hash("Passw0rd!")
         user.mfa_enabled = True
         secret = random_base32()
@@ -63,6 +66,7 @@ def test_login_with_totp_hyphen(client, app):
         User.query.filter_by(email="mfa4@example.com").delete()
         db.session.commit()
         user = User(username="mfauser4", email="mfa4@example.com", status="approved")
+        user.email_verified_at = datetime.utcnow()
         user.password_hash = generate_password_hash("Passw0rd!")
         user.mfa_enabled = True
         secret = random_base32()
@@ -90,6 +94,7 @@ def test_login_with_recovery_code(client, app):
         User.query.filter_by(email="mfa2@example.com").delete()
         db.session.commit()
         user = User(username="mfauser2", email="mfa2@example.com", status="approved")
+        user.email_verified_at = datetime.utcnow()
         user.password_hash = generate_password_hash("Passw0rd!")
         user.mfa_enabled = True
         secret = random_base32()
@@ -116,6 +121,7 @@ def test_disable_mfa_with_hyphen(client, app):
         User.query.filter_by(email="mfa5@example.com").delete()
         db.session.commit()
         user = User(username="mfauser5", email="mfa5@example.com", status="approved")
+        user.email_verified_at = datetime.utcnow()
         user.password_hash = generate_password_hash("Passw0rd!")
         user.mfa_enabled = True
         secret = random_base32()
@@ -154,6 +160,7 @@ def test_login_with_email_code(monkeypatch, client, app):
         User.query.filter_by(email="mfaemail@example.com").delete()
         db.session.commit()
         user = User(username="mfaemail", email="mfaemail@example.com", status="approved")
+        user.email_verified_at = datetime.utcnow()
         user.password_hash = generate_password_hash("Passw0rd!")
         user.mfa_enabled = True
         secret = random_base32()
@@ -180,7 +187,10 @@ def test_mfa_verify_masks_email(client, app):
     from utils.mask import mask_email
     email = "mask@example.com"
     with app.app_context():
+        User.query.filter_by(email=email).delete()
+        db.session.commit()
         user = User(username="mask_user", email=email, status="approved")
+        user.email_verified_at = datetime.utcnow()
         user.set_password("Passw0rd!")
         db.session.add(user)
         db.session.commit()

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -1,12 +1,16 @@
 from werkzeug.security import generate_password_hash
+from datetime import datetime
 
 
 def test_password_upgrade_on_login(app, client):
     from app import db, User
 
     with app.app_context():
+        User.query.filter_by(email="l@example.com").delete()
+        db.session.commit()
         u = User(username="legacyuser", email="l@example.com", role="User", status="approved")
         u.password_hash = generate_password_hash("pass")
+        u.email_verified_at = datetime.utcnow()
         db.session.add(u)
         db.session.commit()
 

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -5,6 +5,7 @@ from flask import url_for
 @pytest.fixture
 def login(client):
     from werkzeug.security import generate_password_hash
+    from datetime import datetime
     from app import db, User
 
     def _login(role: str):
@@ -15,6 +16,7 @@ def login(client):
                 user = User(username=role.lower(), email=email, role=role, status="approved")
                 db.session.add(user)
             user.password_hash = generate_password_hash("pass")
+            user.email_verified_at = datetime.utcnow()
             db.session.commit()
         client.post(
             "/auth/login",

--- a/tests/test_superadmin_dashboard.py
+++ b/tests/test_superadmin_dashboard.py
@@ -2,6 +2,7 @@
 
 def create_doctor(app, username="doc"):
     from app import db, User
+    from datetime import datetime
     with app.app_context():
         user = User.query.filter_by(username=username).first()
         if not user:
@@ -11,6 +12,7 @@ def create_doctor(app, username="doc"):
                 role="Doctor",
                 status="approved",
             )
+            user.email_verified_at = datetime.utcnow()
             db.session.add(user)
             db.session.commit()
         return user


### PR DESCRIPTION
## Summary
- require email verification via one-time code before new accounts can log in
- replace unsafe form field macro with auto-escaped attributes
- document email verification across guides and tests

## Testing
- `pytest` *(fails: tests/test_rbac.py::test_nav_visibility[Admin-shows1], tests/test_rbac.py::test_nav_visibility[User-shows3], tests/test_api_json_denied, tests/test_simulations.py::test_simulations_page, tests/test_theme.py::test_theme_cookie_ssr)*

------
https://chatgpt.com/codex/tasks/task_b_68bddf7134dc8332a503fe9518f8fcba