### PR TITLE
feat: redesign signup UI with email verification

### DIFF
--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -93,6 +93,24 @@ def login():
     return render_template("auth/login.html", form=form)
 
 
+@auth_bp.get("/check-username")
+def check_username():
+    """Return availability of a username."""
+    User = current_app.User
+    username = request.args.get("username", "").strip()
+    exists = User.query.filter_by(username=username).first() is not None
+    return jsonify({"available": not exists})
+
+
+@auth_bp.get("/check-email")
+def check_email():
+    """Return availability of an email."""
+    User = current_app.User
+    email = request.args.get("email", "").strip()
+    exists = User.query.filter_by(email=email).first() is not None
+    return jsonify({"available": not exists})
+
+
 @auth_bp.route("/signup", methods=["GET", "POST"])
 def signup():
     """Register a new user. Users activate immediately; Doctors/Admins await approval."""

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -37,6 +37,35 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const strengthLabels = ['Very weak','Weak','Fair','Good','Strong'];
 
+    const usernameGroup = username.closest('.mb-3');
+    const emailGroup = email.closest('.mb-3');
+    usernameGroup.style.position = 'relative';
+    emailGroup.style.position = 'relative';
+    const usernameSpinner = document.createElement('div');
+    usernameSpinner.className = 'spinner-border spinner-border-sm position-absolute top-50 end-0 translate-middle-y me-2 d-none';
+    usernameSpinner.setAttribute('role', 'status');
+    usernameSpinner.setAttribute('aria-hidden', 'true');
+    usernameGroup.appendChild(usernameSpinner);
+    const emailSpinner = document.createElement('div');
+    emailSpinner.className = 'spinner-border spinner-border-sm position-absolute top-50 end-0 translate-middle-y me-2 d-none';
+    emailSpinner.setAttribute('role', 'status');
+    emailSpinner.setAttribute('aria-hidden', 'true');
+    emailGroup.appendChild(emailSpinner);
+
+    const usernameCache = new Map();
+    const emailCache = new Map();
+
+    const debounce = (fn, delay = 400) => {
+      let timer;
+      return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => fn(...args), delay);
+      };
+    };
+
+    let usernameValid = false;
+    let emailValid = false;
+
     function updatePassword() {
       const val = password.value;
       const checks = {
@@ -71,35 +100,129 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function validateEmailFormat() {
       const ok = email.checkValidity();
-      email.classList.toggle('is-invalid', !ok);
-      email.classList.toggle('is-valid', ok && email.value.trim() !== '');
-      if (emailError) emailError.textContent = ok ? '' : 'Enter a valid email address';
+      if (!ok) {
+        email.classList.add('is-invalid');
+        email.classList.remove('is-valid');
+        if (emailError) emailError.textContent = 'Enter a valid email address.';
+      } else {
+        email.classList.remove('is-invalid');
+        if (emailError) emailError.textContent = '';
+      }
       return ok;
     }
 
-    function checkForm() {
-      const passOk = updatePassword();
-      const matchOk = validateConfirm(passOk);
-      const userOk = username.value.trim() !== '';
-      username.classList.toggle('is-invalid', !userOk && username.value.trim() !== '');
-      username.classList.toggle('is-valid', userOk);
-      if (usernameError && userOk) usernameError.textContent = '';
-      const emailFormatOk = validateEmailFormat();
-      if (emailFormatOk && emailError) emailError.textContent = '';
-      const ready = userOk && emailFormatOk && role.value && passOk && matchOk;
-      submit.disabled = !ready;
+    function setUsernameState(available) {
+      usernameValid = available;
+      username.classList.toggle('is-valid', available);
+      username.classList.toggle('is-invalid', !available && username.value.trim() !== '');
+      if (usernameError) usernameError.textContent = available ? '' : 'username already taken';
     }
 
-    ['input', 'change'].forEach(evt => {
-      username.addEventListener(evt, checkForm);
-      email.addEventListener(evt, checkForm);
-      role.addEventListener(evt, checkForm);
-      password.addEventListener(evt, checkForm);
-      confirm.addEventListener(evt, checkForm);
+    const usernameAvailability = async () => {
+      const value = username.value.trim();
+      if (!value) {
+        username.classList.remove('is-valid', 'is-invalid');
+        if (usernameError) usernameError.textContent = '';
+        usernameValid = false;
+        return false;
+      }
+      if (usernameCache.has(value)) {
+        setUsernameState(usernameCache.get(value));
+        return usernameCache.get(value);
+      }
+      usernameSpinner.classList.remove('d-none');
+      try {
+        const resp = await fetch(`/auth/check-username?username=${encodeURIComponent(value)}`);
+        const data = await resp.json();
+        const ok = !!data.available;
+        usernameCache.set(value, ok);
+        setUsernameState(ok);
+        return ok;
+      } catch {
+        usernameValid = false;
+        return false;
+      } finally {
+        usernameSpinner.classList.add('d-none');
+      }
+    };
+
+    const debouncedUsername = debounce(usernameAvailability);
+    username.addEventListener('input', () => {
+      usernameValid = false;
+      username.classList.remove('is-valid', 'is-invalid');
+      if (usernameError) usernameError.textContent = '';
+      debouncedUsername();
+    });
+    username.addEventListener('blur', debouncedUsername);
+
+    function setEmailState(available) {
+      emailValid = available;
+      email.classList.toggle('is-valid', available);
+      email.classList.toggle('is-invalid', !available && email.value.trim() !== '');
+      if (emailError) emailError.textContent = available ? '' : 'email already registered — Sign in?';
+    }
+
+    const emailAvailability = async () => {
+      const value = email.value.trim();
+      if (!value) {
+        email.classList.remove('is-valid', 'is-invalid');
+        if (emailError) emailError.textContent = '';
+        emailValid = false;
+        return false;
+      }
+      if (!validateEmailFormat()) {
+        emailValid = false;
+        return false;
+      }
+      if (emailCache.has(value)) {
+        setEmailState(emailCache.get(value));
+        return emailCache.get(value);
+      }
+      emailSpinner.classList.remove('d-none');
+      try {
+        const resp = await fetch(`/auth/check-email?email=${encodeURIComponent(value)}`);
+        const data = await resp.json();
+        const ok = !!data.available;
+        emailCache.set(value, ok);
+        setEmailState(ok);
+        return ok;
+      } catch {
+        emailValid = false;
+        return false;
+      } finally {
+        emailSpinner.classList.add('d-none');
+      }
+    };
+
+    const debouncedEmail = debounce(emailAvailability);
+    email.addEventListener('input', () => {
+      emailValid = false;
+      if (!validateEmailFormat()) return;
+      email.classList.remove('is-valid');
+      if (emailError) emailError.textContent = '';
+      debouncedEmail();
+    });
+    email.addEventListener('blur', debouncedEmail);
+
+    function formIsValid() {
+      const passOk = updatePassword();
+      const matchOk = validateConfirm(passOk);
+      const roleOk = !!role.value;
+      return usernameValid && emailValid && passOk && matchOk && roleOk;
+    }
+
+    password.addEventListener('input', () => {
+      const passOk = updatePassword();
+      validateConfirm(passOk);
+    });
+    confirm.addEventListener('input', () => {
+      validateConfirm(updatePassword());
     });
 
     signupForm.addEventListener('submit', async e => {
       e.preventDefault();
+      await Promise.all([usernameAvailability(), emailAvailability()]);
+      if (!formIsValid()) return;
       submit.disabled = true;
       const resp = await fetch(signupForm.action, {
         method: 'POST',
@@ -117,11 +240,9 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         const data = await resp.json().catch(() => ({}));
         if (data.error === 'username') {
-          username.classList.add('is-invalid');
-          if (usernameError) usernameError.textContent = 'Username taken';
+          setUsernameState(false);
         } else if (data.error === 'email') {
-          email.classList.add('is-invalid');
-          if (emailError) emailError.textContent = 'Email already registered';
+          setEmailState(false);
         }
       }
     });

--- a/templates/_components/form_field.html
+++ b/templates/_components/form_field.html
@@ -10,6 +10,6 @@
   <input type="{{ type }}" class="form-control{% if error %} is-invalid{% endif %}" id="{{ name }}" name="{{ name }}" value="{{ value }}"{% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>
   {% endif %}
   {% if help %}<div class="form-text text-muted" id="{{ name }}Help">{{ help }}</div>{% endif %}
-  {% if error %}<div class="invalid-feedback">{{ error }}</div>{% endif %}
+  <div class="invalid-feedback" aria-live="polite">{% if error %}{{ error }}{% endif %}</div>
 </div>
 {%- endmacro %}

--- a/templates/auth/signup.html
+++ b/templates/auth/signup.html
@@ -29,19 +29,19 @@
       {% call auth_card('Create your account') %}
       <form id="signupForm" method="post" action="{{ url_for('auth.signup') }}" novalidate>
         {{ form.csrf_token }}
-        {{ form_field('text', form.username.id, form.username.label.text, value=form.username.data or '', error='', attrs={'required':True, 'autocomplete':'username'}) }}
+        {{ form_field('text', form.username.id, form.username.label.text, value=form.username.data or '', attrs={'required':True, 'autocomplete':'username'}) }}
         {{ form_field('text', form.nickname.id, form.nickname.label.text, value=form.nickname.data or '', attrs={'autocomplete':'nickname'}) }}
-        {{ form_field('email', form.email.id, form.email.label.text, value=form.email.data or '', error='', attrs={'required':True, 'autocomplete':'email'}) }}
-        {{ form_field('password', form.password.id, form.password.label.text, help='Use 8+ characters with numbers and symbols', error='', attrs={'required':True, 'autocomplete':'new-password', 'aria-describedby': form.password.id + 'Help'}, slot='<button type="button" class="btn btn-outline-secondary password-toggle position-absolute top-50 end-0 translate-middle-y me-2" aria-label="Show password"><i class="bi bi-eye"></i></button>') }}
+        {{ form_field('email', form.email.id, form.email.label.text, value=form.email.data or '', attrs={'required':True, 'autocomplete':'email'}) }}
+        {{ form_field('password', form.password.id, form.password.label.text, help='Use 8+ characters with numbers and symbols', attrs={'required':True, 'autocomplete':'new-password', 'aria-describedby': form.password.id + 'Help'}, slot='<button type="button" class="btn btn-outline-secondary password-toggle position-absolute top-50 end-0 translate-middle-y me-2" aria-label="Show password"><i class="bi bi-eye"></i></button>') }}
         {{ password_strength(form.password.id) }}
-        {{ form_field('password', form.confirm.id, form.confirm.label.text, error='', attrs={'required':True, 'autocomplete':'new-password'}, slot='<button type="button" class="btn btn-outline-secondary password-toggle position-absolute top-50 end-0 translate-middle-y me-2" aria-label="Show password"><i class="bi bi-eye"></i></button>') }}
+        {{ form_field('password', form.confirm.id, form.confirm.label.text, attrs={'required':True, 'autocomplete':'new-password'}, slot='<button type="button" class="btn btn-outline-secondary password-toggle position-absolute top-50 end-0 translate-middle-y me-2" aria-label="Show password"><i class="bi bi-eye"></i></button>') }}
         <div class="mb-3">
           {{ form.role.label(class='form-label') }}
           {{ form.role(class='form-select', id=form.role.id, required=true) }}
         </div>
         <p class="small text-muted mb-3">By creating an account, you agree to our <a href="#">Terms</a> and <a href="#">Privacy Policy</a>.</p>
         <div class="d-grid mb-3">
-          {{ primary('Create account', attrs={'id':'createAccount', 'type':'submit', 'disabled':True}) }}
+          {{ primary('Create account', attrs={'id':'createAccount', 'type':'submit'}) }}
         </div>
         <p class="text-center mb-0">Already have an account? <a href="{{ url_for('auth.login') }}">Sign in</a></p>
       </form>


### PR DESCRIPTION
## Summary
- add debounced username/email availability checks with client format validation and inline feedback
- expose backend endpoints for username and email availability
- ensure form field macro always renders aria-live invalid feedback

## Testing
- `pytest` *(failed: tests/test_rbac.py::test_nav_visibility[Admin-shows1], tests/test_rbac.py::test_nav_visibility[User-shows3], tests/test_api_json_denied, tests/test_simulations.py::test_simulations_page, tests/test_theme.py::test_theme_cookie_ssr)*

------
https://chatgpt.com/codex/tasks/task_b_68be68e5e1308332b4c033ac89bdf4d1