### PR TITLE
Fix nickname persistence and display

### DIFF
--- a/blueprints/settings/profile.py
+++ b/blueprints/settings/profile.py
@@ -32,7 +32,10 @@ def update_profile():
     User = current_app.User
     current_user.username = request.form.get("username", current_user.username)
     current_user.email = request.form.get("email", current_user.email)
-    nickname = request.form.get("nickname", "").strip() or None
+    raw_nick = request.form.get("nickname", "").strip()
+    nickname = raw_nick or None
+    if raw_nick.lower() == "none":
+        nickname = None
     if nickname and db.session.query(User).filter(User.nickname == nickname, User.id != current_user.id).first():
         flash("Nickname already taken", "error")
         return redirect(url_for("settings.settings"))

--- a/templates/_components/form_field.html
+++ b/templates/_components/form_field.html
@@ -3,11 +3,11 @@
   <label for="{{ name }}" class="form-label">{{ label }}</label>
   {% if slot %}
   <div class="position-relative">
-    <input type="{{ type }}" class="form-control{% if error %} is-invalid{% endif %}" id="{{ name }}" name="{{ name }}" value="{{ value }}"{% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>
+    <input type="{{ type }}" class="form-control{% if error %} is-invalid{% endif %}" id="{{ name }}" name="{{ name }}" value="{{ value|default('', true) }}"{% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>
     {{ slot|safe }}
   </div>
   {% else %}
-  <input type="{{ type }}" class="form-control{% if error %} is-invalid{% endif %}" id="{{ name }}" name="{{ name }}" value="{{ value }}"{% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>
+  <input type="{{ type }}" class="form-control{% if error %} is-invalid{% endif %}" id="{{ name }}" name="{{ name }}" value="{{ value|default('', true) }}"{% for k,v in attrs.items() %} {{k}}="{{v}}"{% endfor %}>
   {% endif %}
   {% if help %}<div class="form-text text-muted" id="{{ name }}Help">{{ help }}</div>{% endif %}
   <div class="invalid-feedback" aria-live="polite">{% if error %}{{ error }}{% endif %}</div>

--- a/templates/settings/index.html
+++ b/templates/settings/index.html
@@ -24,7 +24,7 @@
         {{ avatar(url_for('static', filename='avatars/' ~ (current_user.avatar or 'None.jpg')), current_user.username) }}
         <p class="fw-semibold mt-3 mb-0">{{ current_user.username }}</p>
         <p class="text-muted small mb-0">{{ current_user.email }}</p>
-        <p class="text-muted small">{{ current_user.nickname }}</p>
+        <p class="text-muted small">{{ current_user.nickname or '' }}</p>
       </div>
     </div>
   </aside>


### PR DESCRIPTION
## Summary
- Handle `None` nicknames gracefully when updating profile
- Avoid rendering the literal `None` in form fields
- Show blank nickname when not set in settings page

## Testing
- `pytest` *(fails: tests/test_rbac.py::test_nav_visibility[Admin-shows1], tests/test_rbac.py::test_nav_visibility[User-shows3], tests/test_rbac.py::test_api_json_denied, tests/test_simulations.py::test_simulations_page, tests/test_theme.py::test_theme_cookie_ssr)*

------
https://chatgpt.com/codex/tasks/task_b_68beab1ccd788332a62e8d49af8f5da9