### PR TITLE
docs: update project structure and add engineering overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,42 +91,42 @@ honors `prefers-reduced-motion` for accessibility.
 
 ## 📂 Project Structure
 ```text
-heart-app/
+Heartlytics/
 ├── app.py               # Application entry point
 ├── config.py            # Configuration classes
 ├── helpers.py           # Shared utility functions
+├── navigation.py        # Navbar helpers and role checks
 ├── outlier_detection.py # Outlier detection helpers
+├── manage_keys.py       # Development key management
 ├── auth/                # Authentication blueprint and forms
 ├── doctor/              # Doctor dashboard
-├── routes/              # Core Flask blueprints
+├── user/                # User dashboard
+├── superadmin/          # Administration tools
+├── routes/              # Core Flask routes
 │   ├── __init__.py
-│   ├── predict.py
-│   └── settings.py
-├── services/            # Business logic and ML helpers
+│   ├── debug.py
+│   └── predict.py
+├── blueprints/          # Additional blueprint packages
+│   └── settings/
+├── services/            # Business logic and helpers
 │   ├── auth.py
+│   ├── crypto/
 │   ├── data.py
+│   ├── email.py
+│   ├── mfa.py
+│   ├── otp.py
 │   ├── pdf.py
 │   ├── security.py
-│   └── simulation.py
+│   ├── simulation.py
+│   └── theme.py
 ├── simulations/         # What-if risk modules
-├── superadmin/          # Superadmin dashboard and management
-├── user/                # Basic user dashboard
 ├── templates/           # Jinja2 templates
-│   ├── base.html
-│   ├── error.html
-│   └── predict/
-│       ├── form.html
-│       └── result.html
-├── static/              # CSS, images and sample files
-│   ├── styles.css
-│   ├── logo.svg
-│   └── sample.csv
-├── ml/                  # Trained model artifacts
-│   └── model.pkl
+├── static/              # CSS, JS, images and sample files
+├── docs/                # Project documentation
 ├── tests/               # Pytest suites
-│   ├── test_predict.py
-│   └── ...
-├── research_paper.tex   # Research paper content
+├── ml/                  # Trained model artifacts
+├── migrations/          # Database migrations
+├── utils/               # Utility scripts
 └── requirements.txt     # Python dependencies
 ```
 
@@ -141,12 +141,18 @@ heart-app/
 
 ---
 
+## 🧱 Software Engineering
+
+Heartlytics follows a modular Flask architecture organized by blueprints and a dedicated service layer. Iterative development, extensive testing, and security-focused design guide implementation. See [docs/software_engineering.md](docs/software_engineering.md) for methodology and architectural details.
+
+---
+
 ## 🚀 Quickstart
 
 ### 1. Clone the repo
 ```bash
-git clone https://github.com/rasikasrimal/heart-disease-risk-app.git
-cd heart-disease-risk-app
+git clone https://github.com/rasikasrimal/Heartlytics.git
+cd Heartlytics
 ```
 
 ### 2. Create a virtual environment

--- a/docs/software_engineering.md
+++ b/docs/software_engineering.md
@@ -1,0 +1,17 @@
+# Software Engineering Methodology and Architecture
+
+This document summarizes the engineering practices and design choices behind **Heartlytics**.
+
+## Methodology
+- **Iterative development** with Git version control and code reviews to maintain quality.
+- **Testing** through pytest suites covering authentication, predictions, and security-critical flows.
+- **Documentation** in Markdown files to capture design decisions and operating procedures.
+- **Security-first mindset**: features are built with encryption, CSRF protection, and MFA.
+
+## Architecture
+- **Flask Blueprints** segment functionality into domains like auth, doctor, user, and admin dashboards.
+- **Service layer** in `services/` encapsulates business logic for authentication, data processing, PDF generation, and more, keeping routes slim.
+- **Modular templates**: Jinja2 templates are organized by feature with reusable components under `templates/_components`.
+- **Extensible design**: new blueprints or services can be added without impacting existing modules thanks to clear boundaries.
+
+These approaches yield a maintainable, testable, and secure codebase suitable for ongoing enhancements.


### PR DESCRIPTION
## Summary
- update README project structure and cloning instructions to match current layout
- add software_engineering.md detailing development methodology and architecture

## Testing
- `pytest` *(fails: tests/test_rbac.py::test_nav_visibility[Admin-shows1], tests/test_rbac.py::test_nav_visibility[User-shows3], tests/test_api_json_denied, tests/test_simulations.py::test_simulations_page, tests/test_theme.py::test_theme_cookie_ssr)*

------
https://chatgpt.com/codex/tasks/task_b_68c0156c08688333a33539a4deb4164b