### PR TITLE
docs: add code of conduct and contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: "Bug report"
+description: "Report something that isn't working as expected."
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report an issue. Please fill out the checklist so we can reproduce it quickly.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Issue checklist
+      options:
+        - label: I have searched existing issues to ensure this has not already been reported.
+          required: true
+        - label: I am using the latest version of Heartlytics (or have noted the exact version below).
+          required: true
+  - type: input
+    id: version
+    attributes:
+      label: Heartlytics version
+      description: Include the git commit SHA, release number, or branch name.
+      placeholder: e.g. v1.4.0 or 9b3d2f1
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: Provide a clear and concise description of what the bug is.
+      placeholder: When I ...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the minimal steps needed to reproduce the issue.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or logs
+      description: Attach screenshots, stack traces, or console output that help explain the problem.
+      placeholder: Drag and drop images or paste log output here.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: Operating system, browser (if applicable), Python version, and other relevant context.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerabilities
+    url: https://github.com/Heartlytics/Heartlytics/security/policy
+    about: Please report security issues through our coordinated disclosure program.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: "Feature request"
+description: "Suggest an idea for Heartlytics."
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Share as much detail as you can so we can evaluate it quickly.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Issue checklist
+      options:
+        - label: I have searched existing issues to make sure this idea hasn't already been proposed.
+          required: true
+        - label: This feature will not expose sensitive data or weaken patient privacy safeguards.
+          required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What problem are you trying to solve?
+      placeholder: I would like to...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the change you would like to see and why it helps users.
+      placeholder: |
+        - Update the...
+        - Add a new...
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you looked at other solutions or workarounds?
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, mockups, metrics, or anything else we should consider.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+- _Provide a short summary of the changes and their impact._
+
+## Testing
+- _List the commands or steps you ran to validate your changes._
+
+## Checklist
+- [ ] I read the [Contributing Guide](../CONTRIBUTING.md) and followed the workflow described there.
+- [ ] I added or updated tests and documentation as needed.
+- [ ] I verified that sensitive data (keys, secrets, PHI) are not exposed in this change.
+- [ ] I confirmed all CI checks pass locally or explained why they are not applicable.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the Heartlytics community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [community@heartlytics.app](mailto:community@heartlytics.app). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at the [Contributor Covenant translations](https://www.contributor-covenant.org/translations).
+
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Heartlytics
+
+Thank you for taking the time to improve the Heart Disease Risk Prediction web application! These guidelines outline the
+expectations for contributors and the workflow we follow to keep the project healthy.
+
+## 🧭 Ways to Contribute
+- Fix bugs or implement new features in Flask blueprints, services, or templates.
+- Improve the machine learning helpers, batch analysis utilities, or simulations.
+- Enhance automated tests under `tests/` or add fixtures.
+- Expand documentation in `docs/` or update this file when the workflow changes.
+
+If you are unsure whether an idea fits the project, open a GitHub issue first so we can discuss it.
+
+## 🛠 Development Environment
+1. Fork the repository and clone your fork.
+2. Create a virtual environment and activate it:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate   # Linux / macOS
+   .venv\Scripts\activate      # Windows
+   ```
+3. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Copy `.env.example` to `.env` and adjust values for your environment. At a minimum set secrets, email credentials, and any
+   encryption keys you require for local testing.
+5. Run the development server with `flask run` and visit http://127.0.0.1:5000.
+
+## ✅ Pull Request Checklist
+Before submitting a PR, please ensure:
+- [ ] Code is formatted according to PEP 8. We recommend using `black` or your editor's auto-formatting.
+- [ ] Unit tests pass locally with `pytest`.
+- [ ] Relevant templates render in both light and dark mode without breaking layout.
+- [ ] Any new configuration values are documented in `README.md` (environment variables table) and have sensible defaults.
+- [ ] User-facing changes include screenshots or GIFs in the PR description when possible.
+- [ ] Documentation or inline comments are updated alongside code changes.
+
+## 🧪 Testing
+We rely on the `pytest` suite in the `tests/` directory. Please add or update tests that cover new functionality or bug fixes.
+Run them locally before pushing changes:
+```bash
+pytest
+```
+If you add new CLI commands, services, or template logic, include tests or fixtures demonstrating expected behavior.
+
+## 🔐 Security & Privacy Notes
+- Never commit real secrets, private keys, or production datasets. Use `.env` or example values instead.
+- Respect the encryption helpers in `services/security.py` and `helpers.py`; do not bypass them when touching encrypted
+  models or database fields.
+- Validate and sanitize all new user inputs. Follow existing patterns for CSRF protection and Flask form validation.
+
+## 🗂 Branching & Commit Messages
+- Create feature branches from `main` with a descriptive name (e.g., `feature/improve-batch-eda`).
+- Write concise commit messages (present tense) that explain the change, e.g., `Add PDF export button to doctor dashboard`.
+- Squash or rebase your branch to keep history clean before opening the PR.
+
+## 💬 Communication
+- Use draft pull requests for work-in-progress to gather early feedback.
+- Reference related issues with `Fixes #123` or `Closes #123` in the PR description when applicable.
+- Be respectful and collaborative. Follow the [GitHub Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines) in discussions and reviews.
+
+We appreciate your help in making Heartlytics a reliable tool for understanding heart disease risk. Happy coding!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+We actively maintain the latest production release and the `main` branch. Older snapshots or forks are not covered by security updates.
+
+| Version        | Supported          |
+| -------------- | ------------------ |
+| `main` branch  | ✅                  |
+| Tagged releases within the last 12 months | ✅ |
+| Anything older | ❌                  |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Heartlytics, **please do not open a public issue**. Instead, email the core team at [security@heartlytics.app](mailto:security@heartlytics.app) with the following details:
+
+1. A clear description of the vulnerability and the potential impact.
+2. The steps required to reproduce the issue, including proof-of-concept code if possible.
+3. Any mitigating factors you have identified.
+4. A preferred way to reach you for follow-up questions.
+
+We will acknowledge receipt of your report within **48 hours** and aim to provide an initial assessment within **5 business days**. Throughout the process we will keep you updated as we work on a fix. When a resolution is ready, we will coordinate disclosure so the community has time to update before details are made public.
+
+## Preferred Languages
+
+We can review reports written in English.
+
+## Safe Harbor
+
+We will not pursue legal action for good-faith, coordinated vulnerability disclosure activities that comply with this policy and applicable laws.


### PR DESCRIPTION
## Summary
- add a Contributor Covenant-based code of conduct with reporting instructions
- provide bug and feature issue templates plus guidance for security disclosures
- add a pull request template reinforcing the contributing workflow and safety checks

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68e091ba9294832da3f7e8b556a3e06e